### PR TITLE
Fix review findings: security, encoding, packaging, and test guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ build/
 .coverage
 htmlcov/
 
+# Type checking
+.mypy_cache/
+
 # IDE
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Model: Opus 4.6 (1M context) | Context: 7% | 5h: 11% | 1w: 4% (2m)
 | Freshness | `(2m)` = 2 min old, fresh. `(!5m)` = 5 min old, last fetch failed |
 | Session / Today | Vertex mode only — session and daily cost from stdin |
 
-Quota data is cached for 5 minutes. On API failure (429/error), stale cache is used and the freshness indicator shows `!`.
+Quota data is cached for 2 minutes. On API failure (429/error), stale cache is used and the freshness indicator shows `!`.
 
 ## Deployment
 

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -190,15 +190,19 @@ def main(argv=None):
         return EXIT_ERROR
 
     changed = False
-    changed |= reconcile_claude_md(
-        args.src, args.dest, dryrun=args.dryrun, quiet=args.quiet
-    )
-    changed |= reconcile_settings(
-        args.src, args.dest, dryrun=args.dryrun, quiet=args.quiet
-    )
-    changed |= reconcile_scripts(
-        args.src.parent, args.dest, dryrun=args.dryrun, quiet=args.quiet
-    )
+    try:
+        changed |= reconcile_claude_md(
+            args.src, args.dest, dryrun=args.dryrun, quiet=args.quiet
+        )
+        changed |= reconcile_settings(
+            args.src, args.dest, dryrun=args.dryrun, quiet=args.quiet
+        )
+        changed |= reconcile_scripts(
+            args.src.parent, args.dest, dryrun=args.dryrun, quiet=args.quiet
+        )
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error(f"reconcile failed: {exc}")
+        return EXIT_ERROR
 
     if not changed:
         if not args.quiet:

--- a/scripts/session_tracker.py
+++ b/scripts/session_tracker.py
@@ -15,6 +15,7 @@ Layout:
 """
 
 import json
+import re
 from datetime import date
 from pathlib import Path
 
@@ -27,11 +28,15 @@ def track_session(data, base_dir=DEFAULT_DIR):
     if not session_id:
         return
 
+    # Reject session_ids that could escape the target directory
+    if not re.match(r"^[\w-]+$", session_id):
+        return
+
     today_dir = Path(base_dir) / date.today().isoformat()
     try:
         today_dir.mkdir(parents=True, exist_ok=True)
         session_file = today_dir / f"{session_id}.json"
-        with open(session_file, "w") as fh:
+        with open(session_file, "w", encoding="utf-8") as fh:
             json.dump(data, fh)
     except OSError:
         pass
@@ -48,7 +53,7 @@ def get_daily_cost(base_dir=DEFAULT_DIR):
         if not session_file.suffix == ".json":
             continue
         try:
-            with open(session_file, "r") as fh:
+            with open(session_file, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
             total += (data.get("cost") or {}).get("total_cost_usd", 0.0)
         except (json.JSONDecodeError, OSError):

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -5,7 +5,7 @@
 Output: Model | Context | 5h | 1w (freshness) | Session | Today
 
 Quota utilization is fetched from the Anthropic OAuth usage API.
-Cached for 5 minutes; on 429/error, stale cache is used.
+Cached for 2 minutes; on 429/error, stale cache is used.
 Freshness indicator shows age and fetch status:
   (2m)  = data is 2 minutes old, last fetch succeeded
   (!5m) = data is 5 minutes old, last fetch failed
@@ -138,7 +138,7 @@ def main():
     is_vertex = bool(os.environ.get("CLAUDE_CODE_USE_VERTEX"))
 
     if is_vertex:
-        from session_tracker import get_daily_cost, track_session
+        from scripts.session_tracker import get_daily_cost, track_session
 
         track_session(data)
         cost = (data.get("cost") or {}).get("total_cost_usd")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,10 @@ BLOCKED_PATHS = [
 
 
 def _is_blocked(path: pathlib.Path) -> bool:
-    resolved = str(path.resolve())
-    return any(resolved.startswith(str(b)) for b in BLOCKED_PATHS)
+    try:
+        return any(path.resolve().is_relative_to(b) for b in BLOCKED_PATHS)
+    except (OSError, ValueError):
+        return True
 
 
 def _guard_read_text(original):
@@ -44,19 +46,31 @@ def _guard_copy2(original):
     return guarded
 
 
+def _guard_open(original):
+    def guarded(file, *args, **kwargs):
+        if _is_blocked(pathlib.Path(file)):
+            raise PermissionError(f"test attempted to open protected path: {file}")
+        return original(file, *args, **kwargs)
+
+    return guarded
+
+
 @pytest.fixture(autouse=True)
 def block_real_config_writes(monkeypatch):
-    """Block all writes to ~/.claude and ~/.config/claude in every test."""
-    original_write_text = pathlib.Path.write_text
-    original_copy2 = __import__("shutil").copy2
+    """Block all I/O to ~/.claude and ~/.config/claude in every test."""
+    import builtins
 
     original_read_text = pathlib.Path.read_text
+    original_write_text = pathlib.Path.write_text
+    original_copy2 = __import__("shutil").copy2
+    original_open = builtins.open
 
     monkeypatch.setattr(pathlib.Path, "read_text", _guard_read_text(original_read_text))
     monkeypatch.setattr(
         pathlib.Path, "write_text", _guard_write_text(original_write_text)
     )
     monkeypatch.setattr("shutil.copy2", _guard_copy2(original_copy2))
+    monkeypatch.setattr("builtins.open", _guard_open(original_open))
 
 
 @pytest.fixture

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -4,18 +4,17 @@
 
 import json
 import pathlib
-import sys
 
 import pytest
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
-from reconcile import (  # noqa: E402
+from scripts.reconcile import (
     EXIT_ERROR,
     EXIT_SUCCESS,
+    main,
     merge_settings,
     reconcile_claude_md,
+    reconcile_scripts,
     reconcile_settings,
-    main,
 )
 
 
@@ -222,6 +221,91 @@ class TestReconcileSettings:
         assert changed is False
 
 
+class TestReconcileScripts:
+    def test_copies_scripts(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        dest_dir = tmp_path / "dest"
+        scripts_dir = repo_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        dest_dir.mkdir()
+        (scripts_dir / "foo.py").write_text("print(1)")
+        (scripts_dir / "bar.py").write_text("print(2)")
+
+        changed = reconcile_scripts(repo_dir, dest_dir)
+
+        assert changed is True
+        dest_scripts = dest_dir / "my-claude-stuff" / "scripts"
+        assert (dest_scripts / "foo.py").read_text() == "print(1)"
+        assert (dest_scripts / "bar.py").read_text() == "print(2)"
+
+    def test_skips_identical_files(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        dest_dir = tmp_path / "dest"
+        scripts_dir = repo_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        dest_scripts = dest_dir / "my-claude-stuff" / "scripts"
+        dest_scripts.mkdir(parents=True)
+        (scripts_dir / "same.py").write_text("same")
+        (dest_scripts / "same.py").write_text("same")
+
+        changed = reconcile_scripts(repo_dir, dest_dir)
+
+        assert changed is False
+
+    def test_overwrites_changed_files(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        dest_dir = tmp_path / "dest"
+        scripts_dir = repo_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        dest_scripts = dest_dir / "my-claude-stuff" / "scripts"
+        dest_scripts.mkdir(parents=True)
+        (scripts_dir / "mod.py").write_text("new")
+        (dest_scripts / "mod.py").write_text("old")
+
+        changed = reconcile_scripts(repo_dir, dest_dir)
+
+        assert changed is True
+        assert (dest_scripts / "mod.py").read_text() == "new"
+
+    def test_dryrun_does_not_write(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        dest_dir = tmp_path / "dest"
+        scripts_dir = repo_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        dest_dir.mkdir()
+        (scripts_dir / "new.py").write_text("content")
+
+        changed = reconcile_scripts(repo_dir, dest_dir, dryrun=True)
+
+        assert changed is True
+        assert not (dest_dir / "my-claude-stuff" / "scripts" / "new.py").exists()
+
+    def test_missing_scripts_dir(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        changed = reconcile_scripts(repo_dir, dest_dir)
+
+        assert changed is False
+
+    def test_only_copies_py_files(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        dest_dir = tmp_path / "dest"
+        scripts_dir = repo_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        dest_dir.mkdir()
+        (scripts_dir / "good.py").write_text("ok")
+        (scripts_dir / "notes.txt").write_text("skip me")
+
+        reconcile_scripts(repo_dir, dest_dir)
+
+        dest_scripts = dest_dir / "my-claude-stuff" / "scripts"
+        assert (dest_scripts / "good.py").exists()
+        assert not (dest_scripts / "notes.txt").exists()
+
+
 class TestMain:
     def test_returns_error_when_src_missing(self, tmp_path):
         result = main([str(tmp_path / "nonexistent"), str(tmp_path / "dest")])
@@ -263,19 +347,92 @@ class TestMain:
         assert captured.out == ""
 
 
-class TestBlockRealConfigWrites:
-    """Verify the conftest guard blocks writes to real config paths."""
+class TestConfTestGuard:
+    """Verify the conftest guard blocks all I/O to protected paths.
 
-    def test_write_to_real_claude_dir_blocked(self):
-        real_path = pathlib.Path.home() / ".claude" / "test_canary.txt"
+    Every guard must block both ~/.claude and ~/.config/claude,
+    and must fail closed (block on error, never allow through).
+    """
+
+    # --- write_text ---
+
+    def test_write_text_blocked_claude_dir(self):
+        path = pathlib.Path.home() / ".claude" / "canary.txt"
         with pytest.raises(PermissionError, match="protected path"):
-            real_path.write_text("should not be written")
+            path.write_text("blocked")
 
-    def test_copy_to_real_claude_dir_blocked(self, tmp_path):
+    def test_write_text_blocked_config_claude_dir(self):
+        path = pathlib.Path.home() / ".config" / "claude" / "canary.txt"
+        with pytest.raises(PermissionError, match="protected path"):
+            path.write_text("blocked")
+
+    def test_write_text_blocked_nested_subdir(self):
+        path = pathlib.Path.home() / ".claude" / "deep" / "nested" / "f.txt"
+        with pytest.raises(PermissionError, match="protected path"):
+            path.write_text("blocked")
+
+    # --- read_text ---
+
+    def test_read_text_blocked_claude_dir(self):
+        path = pathlib.Path.home() / ".claude" / "canary.txt"
+        with pytest.raises(PermissionError, match="protected path"):
+            path.read_text()
+
+    def test_read_text_blocked_config_claude_dir(self):
+        path = pathlib.Path.home() / ".config" / "claude" / "canary.txt"
+        with pytest.raises(PermissionError, match="protected path"):
+            path.read_text()
+
+    # --- shutil.copy2 ---
+
+    def test_copy2_blocked(self, tmp_path):
         import shutil
 
         src = tmp_path / "src.txt"
         src.write_text("canary")
-        dest = pathlib.Path.home() / ".claude" / "test_canary.txt"
+        dest = pathlib.Path.home() / ".claude" / "canary.txt"
         with pytest.raises(PermissionError, match="protected path"):
             shutil.copy2(src, dest)
+
+    # --- builtins.open ---
+
+    def test_open_write_blocked_claude_dir(self):
+        path = pathlib.Path.home() / ".claude" / "canary.txt"
+        with pytest.raises(PermissionError, match="protected path"):
+            open(path, "w")
+
+    def test_open_read_blocked_claude_dir(self):
+        path = pathlib.Path.home() / ".claude" / "canary.txt"
+        with pytest.raises(PermissionError, match="protected path"):
+            open(path, "r")
+
+    def test_open_blocked_config_claude_dir(self):
+        path = pathlib.Path.home() / ".config" / "claude" / "canary.txt"
+        with pytest.raises(PermissionError, match="protected path"):
+            open(path, "r")
+
+    # --- tmp_path is allowed ---
+
+    def test_write_text_allowed_tmp_path(self, tmp_path):
+        path = tmp_path / "ok.txt"
+        path.write_text("allowed")
+        assert path.read_text() == "allowed"
+
+    def test_open_allowed_tmp_path(self, tmp_path):
+        path = tmp_path / "ok.txt"
+        with open(path, "w") as fh:
+            fh.write("allowed")
+        with open(path, "r") as fh:
+            assert fh.read() == "allowed"
+
+    # --- fail closed: _is_blocked returns True on error ---
+
+    def test_is_blocked_fails_closed(self, monkeypatch):
+        from tests.conftest import _is_blocked
+
+        # Force resolve() to raise, simulating an unresolvable path
+        def bad_resolve(self):
+            raise OSError("cannot resolve")
+
+        monkeypatch.setattr(pathlib.Path, "resolve", bad_resolve)
+        assert _is_blocked(pathlib.Path("/some/random/path")) is True

--- a/tests/test_session_tracker.py
+++ b/tests/test_session_tracker.py
@@ -3,14 +3,11 @@
 """Tests for scripts/session_tracker.py."""
 
 import json
-import pathlib
-import sys
 from datetime import date
 
 import pytest
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
-from session_tracker import get_daily_cost, track_session  # noqa: E402
+from scripts.session_tracker import get_daily_cost, track_session
 
 
 def _make_session_data(session_id="abc-123", cost_usd=1.50):
@@ -59,6 +56,16 @@ class TestTrackSession:
 
     def test_skips_missing_session_id(self, tmp_path):
         data = {"cost": {"total_cost_usd": 1.00}}
+        track_session(data, base_dir=tmp_path)
+        assert not list(tmp_path.iterdir())
+
+    def test_rejects_path_traversal(self, tmp_path):
+        data = _make_session_data(session_id="../../etc/evil")
+        track_session(data, base_dir=tmp_path)
+        assert not list(tmp_path.iterdir())
+
+    def test_rejects_slash_in_session_id(self, tmp_path):
+        data = _make_session_data(session_id="foo/bar")
         track_session(data, base_dir=tmp_path)
         assert not list(tmp_path.iterdir())
 

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -12,7 +12,7 @@ import time
 
 import pytest
 
-import statusline
+from scripts import statusline
 
 SAMPLE_USAGE_RESPONSE = {
     "five_hour": {
@@ -338,7 +338,7 @@ class TestMain:
         mock_tracker.get_daily_cost = lambda: 5.25
         monkeypatch.setitem(
             __import__("sys").modules,
-            "session_tracker",
+            "scripts.session_tracker",
             mock_tracker,
         )
 
@@ -366,7 +366,7 @@ class TestMain:
         mock_tracker.get_daily_cost = lambda: 0.0
         monkeypatch.setitem(
             __import__("sys").modules,
-            "session_tracker",
+            "scripts.session_tracker",
             mock_tracker,
         )
 


### PR DESCRIPTION
- Fix path traversal in session_tracker via session_id regex validation
- Add encoding="utf-8" to session_tracker open() calls
- Fix cache TTL docs from 5 min to 2 min in statusline and README
- Make scripts/ a proper package with __init__.py, remove sys.path hacks
- Add error handling in reconcile main() for corrupt JSON
- Extend conftest guard to cover builtins.open, use is_relative_to()
- Make conftest _is_blocked fail closed on resolve errors
- Add .mypy_cache/ to .gitignore
- Add reconcile_scripts tests and comprehensive conftest guard tests

Assisted-by: Claude Code (Claude Opus 4.6)