### PR TITLE
Fix statusline module import when running from deployed location

### DIFF
--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -171,6 +171,7 @@ def main():
     is_vertex = bool(os.environ.get("CLAUDE_CODE_USE_VERTEX"))
 
     if is_vertex:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
         from scripts.session_tracker import get_daily_cost, track_session
 
         track_session(data)


### PR DESCRIPTION
- Add script's parent directory to sys.path before importing session_tracker so the scripts package is found regardless of working directory

Assisted-by: Claude Code (Claude Opus 4.6)