### PR TITLE
Add click-to-focus VS Code action on desktop notifications

### DIFF
--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -13,6 +13,8 @@ Platform-aware: Linux uses notify-send, Windows is stubbed for future.
 """
 
 import json
+import shlex
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -23,6 +25,7 @@ class Notification:
     title: str
     body: str
     urgency: str  # "low", "normal", "critical"
+    cwd: str = ""
 
 
 ACTIONABLE_NOTIFICATION_TYPES = {
@@ -43,6 +46,8 @@ def parse_hook_input(data: dict) -> Notification | None:
     """Parse hook JSON and return a Notification, or None if not actionable."""
     event = data.get("hook_event_name", "")
 
+    cwd = data.get("cwd", "")
+
     if event == "Notification":
         notification_type = data.get("notification_type", "")
         template = ACTIONABLE_NOTIFICATION_TYPES.get(notification_type)
@@ -50,13 +55,16 @@ def parse_hook_input(data: dict) -> Notification | None:
             return None
         message = data.get("message", "")
         body = message if message else template.body
-        return Notification(title=template.title, body=body, urgency=template.urgency)
+        return Notification(
+            title=template.title, body=body, urgency=template.urgency, cwd=cwd
+        )
 
     if event == "Stop":
         return Notification(
             title="Task Complete",
             body="Claude Code has finished responding.",
             urgency="normal",
+            cwd=cwd,
         )
 
     return None
@@ -77,17 +85,51 @@ def detect_platform() -> str:
     return "unknown"
 
 
+def _shell_join(args: list[str]) -> str:
+    """Join command args into a shell-safe string using shlex.quote."""
+    return " ".join(shlex.quote(a) for a in args)
+
+
+def _build_notify_cmd(notification: Notification) -> list[str]:
+    """Build the notify-send command list."""
+    cmd = [
+        "notify-send",
+        "--urgency",
+        notification.urgency,
+    ]
+    if notification.cwd:
+        cmd += ["--action", "focus=Focus"]
+        cmd.append("--wait")
+    cmd += [notification.title, notification.body]
+    return cmd
+
+
 def send_linux(notification: Notification) -> None:
-    """Send notification via notify-send."""
-    subprocess.run(
-        [
-            "notify-send",
-            "--urgency",
-            notification.urgency,
-            notification.title,
-            notification.body,
-        ],
-        check=False,
+    """Send notification via notify-send.
+
+    When cwd is set, spawns a detached background process that waits for the
+    user to click the "Focus" action, then opens VS Code at that workspace.
+    """
+    cmd = _build_notify_cmd(notification)
+
+    if not notification.cwd:
+        subprocess.run(cmd, check=False)
+        return
+
+    code_bin = shutil.which("code") or "code"
+    # Spawn detached process: notify-send --wait prints action key on click,
+    # then we open VS Code at the workspace to focus the window.
+    wrapper_script = (
+        f"action=$({_shell_join(cmd)}) && "
+        f'[ "$action" = "focus" ] && '
+        f"exec {_shell_join([code_bin, notification.cwd])}"
+    )
+    subprocess.Popen(
+        ["bash", "-c", wrapper_script],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -21,12 +21,14 @@ class TestParseHookInput:
             "hook_event_name": "Notification",
             "notification_type": "permission_prompt",
             "message": "Allow Bash(git status)?",
+            "cwd": "/home/user/project",
         }
         result = notify.parse_hook_input(data)
         assert result is not None
         assert result.title == "Approval Needed"
         assert result.body == "Allow Bash(git status)?"
         assert result.urgency == "critical"
+        assert result.cwd == "/home/user/project"
 
     def test_permission_prompt_no_message(self):
         data = {
@@ -71,11 +73,18 @@ class TestParseHookInput:
         assert notify.parse_hook_input(data) is None
 
     def test_stop_event(self):
-        data = {"hook_event_name": "Stop"}
+        data = {"hook_event_name": "Stop", "cwd": "/home/user/project"}
         result = notify.parse_hook_input(data)
         assert result is not None
         assert result.title == "Task Complete"
         assert result.urgency == "normal"
+        assert result.cwd == "/home/user/project"
+
+    def test_cwd_defaults_to_empty(self):
+        data = {"hook_event_name": "Stop"}
+        result = notify.parse_hook_input(data)
+        assert result is not None
+        assert result.cwd == ""
 
     def test_unknown_event_ignored(self):
         data = {"hook_event_name": "SessionStart"}
@@ -128,8 +137,39 @@ class TestDetectPlatform:
         assert notify.detect_platform() == "unknown"
 
 
+class TestShellJoin:
+    def test_simple_args(self):
+        assert notify._shell_join(["echo", "hello"]) == "echo hello"
+
+    def test_args_with_spaces(self):
+        result = notify._shell_join(["code", "/path/with spaces/dir"])
+        assert "with spaces" in result
+        # Should be quoted
+        assert "'" in result or "\\" in result
+
+
+class TestBuildNotifyCmd:
+    def test_without_cwd(self):
+        n = notify.Notification(title="Test", body="Hello", urgency="normal")
+        cmd = notify._build_notify_cmd(n)
+        assert cmd == ["notify-send", "--urgency", "normal", "Test", "Hello"]
+        assert "--action" not in cmd
+        assert "--wait" not in cmd
+
+    def test_with_cwd(self):
+        n = notify.Notification(
+            title="Test", body="Hello", urgency="normal", cwd="/home/user/project"
+        )
+        cmd = notify._build_notify_cmd(n)
+        assert "--action" in cmd
+        assert "focus=Focus" in cmd
+        assert "--wait" in cmd
+        assert cmd[-2] == "Test"
+        assert cmd[-1] == "Hello"
+
+
 class TestSendLinux:
-    def test_calls_notify_send(self):
+    def test_calls_notify_send_without_cwd(self):
         n = notify.Notification(title="Test", body="Hello", urgency="normal")
         with mock.patch("notify.subprocess.run") as mock_run:
             notify.send_linux(n)
@@ -144,6 +184,44 @@ class TestSendLinux:
             notify.send_linux(n)
             args = mock_run.call_args[0][0]
             assert args[2] == "critical"
+
+    def test_with_cwd_spawns_background_process(self):
+        n = notify.Notification(
+            title="Test", body="Hello", urgency="normal", cwd="/home/user/project"
+        )
+        with mock.patch("notify.shutil.which", return_value="/usr/bin/code"):
+            with mock.patch("notify.subprocess.Popen") as mock_popen:
+                notify.send_linux(n)
+                mock_popen.assert_called_once()
+                call_args = mock_popen.call_args
+                cmd_list = call_args[0][0]
+                assert cmd_list[0] == "bash"
+                assert cmd_list[1] == "-c"
+                script = cmd_list[2]
+                assert "notify-send" in script
+                assert "focus" in script
+                assert "/home/user/project" in script
+                assert call_args[1]["start_new_session"] is True
+
+    def test_with_cwd_does_not_call_run(self):
+        n = notify.Notification(
+            title="Test", body="Hello", urgency="normal", cwd="/home/user/project"
+        )
+        with mock.patch("notify.shutil.which", return_value="/usr/bin/code"):
+            with mock.patch("notify.subprocess.Popen"):
+                with mock.patch("notify.subprocess.run") as mock_run:
+                    notify.send_linux(n)
+                    mock_run.assert_not_called()
+
+    def test_with_cwd_falls_back_to_code_if_which_fails(self):
+        n = notify.Notification(
+            title="Test", body="Hello", urgency="normal", cwd="/tmp"
+        )
+        with mock.patch("notify.shutil.which", return_value=None):
+            with mock.patch("notify.subprocess.Popen") as mock_popen:
+                notify.send_linux(n)
+                script = mock_popen.call_args[0][0][2]
+                assert "code" in script
 
 
 class TestSendWindows:


### PR DESCRIPTION
- Extract cwd from hook JSON payload and pass through Notification dataclass
- Add --action focus=Focus and --wait flags to notify-send when cwd is available
- Spawn detached background process so hook returns immediately while waiting for click
- On click, run code <cwd> to focus the VS Code window for that workspace
- Fall back to simple notify-send (no action) when cwd is absent

Assisted-by: Claude Code (Claude Opus 4.6)