### PR TITLE
Add GWS CLI mutation blocking for Google Workspace services

### DIFF
--- a/docs/blocked-commands-reference.md
+++ b/docs/blocked-commands-reference.md
@@ -78,6 +78,10 @@ Complete reference for every blocked pattern in `scripts/block_commands.py`.
 |---------|----------|---------|---------------------|------------------------|------|
 | `make reconcile` | All | `make\s+reconcile\b` | Deploys scripts to `~/.claude/` — affects live environment | `make test`, `make format` | Sensitive |
 
+## Google Workspace CLI
+
+The `gws` CLI has 15 blocked patterns covering Gmail, Calendar, Chat, Drive, Sheets, Tasks, Keep, Forms, Workflow, Events, Classroom, and Meet mutations. See [gws-cli-blocking.md](gws-cli-blocking.md) for the full reference including threat model, access policy, and security analysis.
+
 ## Excluded Commands (Not Blocked)
 
 | Command | Why Excluded |

--- a/docs/gws-cli-blocking.md
+++ b/docs/gws-cli-blocking.md
@@ -1,0 +1,196 @@
+# GWS CLI Mutation Blocking
+
+Defense-in-depth blocking for the `gws` (Google Workspace CLI) tool, implemented as PreToolUse hook patterns in `scripts/block_commands.py`.
+
+## Threat Model
+
+- AI agents may invoke `gws` commands autonomously
+- **Email egress is the primary threat** — `gws gmail +send` accepts arbitrary recipients with no restrictions at the CLI level
+- Calendar, Chat, and any service that can communicate externally are secondary egress vectors
+- Shared resources (Sheets, Drive) enable indirect data exfiltration to external collaborators
+- Push notification subscriptions (Events API) create persistent data channels
+
+## Security Architecture
+
+Two independent layers enforce access control:
+
+1. **OAuth scope enforcement** (server-side) — Google's API servers reject requests outside granted scopes. Login with `gws auth login --readonly` to restrict all services to read-only.
+2. **CLI-level pattern blocking** (this implementation) — regex patterns in the PreToolUse hook block mutation commands before they execute, regardless of OAuth scopes.
+
+Neither layer alone is sufficient. OAuth scopes can be re-granted; CLI blocking prevents the AI agent from even attempting mutations.
+
+## Access Policy
+
+| Service | Read | Write | Rationale |
+|---------|------|-------|-----------|
+| Docs | Yes | **No** | Batch payloads obscure scope; indirect exfil via shared docs |
+| Slides | Yes | **No** | Same rationale as Docs |
+| Sheets | Yes | **No** | Indirect exfil via shared sheets |
+| Drive | Yes | **No** | File mutations + permission changes = exfil |
+| Gmail | Yes | **NEVER** | Arbitrary recipient email = primary exfil vector |
+| Calendar | Yes | **NEVER** | Meeting invites to external attendees |
+| Chat | No | **NEVER** | All message egress blocked |
+| Tasks | Yes | **No** | Write operations blocked |
+| Keep | Yes | **No** | Write operations blocked |
+| Forms | Yes | **No** | Write operations blocked |
+| Meet | Yes | **No** | Space creation/modification blocked |
+| Classroom | No | **No** | Entire service blocked |
+| Events | No | **No** | Push notification subscriptions blocked |
+| Workflow | Partial | Partial | Only egress helpers blocked (+file-announce, +email-to-task) |
+
+## Blocked Patterns Reference
+
+### Gmail (NEVER — all mutations)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws gmail +send\|+reply\|+reply-all\|+forward\|+watch` | Helper commands for email send/reply/forward and watch setup | Direct email egress to arbitrary recipients |
+| `gws gmail messages send\|import\|insert\|delete\|...` | API-level message mutations | Send, import, or manipulate email messages |
+| `gws gmail drafts create\|send\|update\|delete` | Draft mutations | Drafts can be sent; create/update is a send precursor |
+| `gws gmail labels create\|delete\|patch\|update` | Label mutations | Label manipulation can affect mail routing/filtering |
+| `gws gmail settings ... create\|update\|delete\|patch` | Settings sub-resource mutations | Forwarding rules, filters, send-as aliases |
+| `gws gmail watch\|stop` | Push notification control | Establishes persistent data channels |
+
+**Allowed**: `messages list/get`, `labels list/get`, `drafts list/get`
+
+### Calendar (NEVER — all mutations)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws calendar +insert` | Helper to create events | External attendee invitations |
+| `gws calendar events insert\|delete\|import\|move\|patch\|quickAdd\|update\|watch` | Event CRUD | Creating/modifying events with external attendees |
+| `gws calendar acl insert\|delete\|patch\|update` | ACL mutations | Calendar sharing permissions |
+| `gws calendar calendars insert\|delete\|patch\|update\|clear` | Calendar CRUD | Calendar creation/deletion |
+| `gws calendar calendarList insert\|delete\|patch\|update` | Calendar list mutations | Subscription management |
+| `gws calendar channels stop` | Channel management | Push notification control |
+
+**Allowed**: `+agenda`, `events list/get/instances`, `calendarList list`
+
+### Chat (NEVER — all egress)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws chat +send` | Helper to send messages | Direct message egress |
+| `gws chat spaces create\|setup\|patch\|delete\|completeImport` | Space management | Creating communication channels |
+| `gws chat messages create\|delete\|patch\|update` | Message CRUD | Sending/modifying messages |
+| `gws chat members create\|delete` | Membership mutations | Adding/removing space members |
+| `gws chat customEmojis create\|delete` | Emoji mutations | Resource creation |
+
+### Drive (No writes)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws drive +upload` | File upload helper | Creates files accessible to collaborators |
+| `gws drive files create\|copy\|delete\|update\|emptyTrash\|modifyLabels` | File CRUD | File mutations and trash management |
+| `gws drive permissions create\|update\|delete` | Permission mutations | Sharing files with external users |
+| `gws drive comments/replies create\|update\|delete` | Comment/reply mutations | Communication via file comments |
+| `gws drive drives create\|delete\|update\|hide\|unhide` | Shared drive mutations | Drive management |
+| `gws drive channels stop` | Channel management | Push notification control |
+
+**Allowed**: `files list/get`, `+download`, `+export`, `permissions list`
+
+### Sheets (No writes)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws sheets +append` | Append helper | Writes data to shared sheets |
+| `gws sheets spreadsheets create\|batchUpdate` | Spreadsheet mutations | Creating/modifying spreadsheets |
+| `gws sheets values append\|update\|batchUpdate\|clear\|...` | Cell value mutations | Writing data to cells |
+| `gws sheets sheets copyTo` | Sheet copy | Duplicates sheets (potential data exposure) |
+
+**Allowed**: `+read`, `values get/batchGet`, `spreadsheets get`
+
+### Tasks, Keep, Forms (No writes)
+
+| Service | Blocked | Why |
+|---------|---------|-----|
+| Tasks | `tasks insert/delete/patch/update/clear/move`, `tasklists insert/delete/patch/update` | Write operations |
+| Keep | `notes create/delete` | Write operations |
+| Forms | `forms create/batchUpdate` | Write operations |
+
+### Docs (No writes)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws docs documents create\|batchUpdate` | Document creation and batch mutations | Batch payloads obscure scope; indirect exfil via shared docs |
+
+**Allowed**: `documents get`
+
+### Slides (No writes)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws slides presentations create\|batchUpdate` | Presentation creation and batch mutations | Same rationale as Docs |
+
+**Allowed**: `presentations get`
+
+### Workflow (Egress helpers only)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws workflow\|wf +file-announce` | File announcement helper | Sends notifications about files |
+| `gws workflow\|wf +email-to-task` | Email-to-task helper | Creates tasks from emails (egress) |
+
+**Allowed**: `+standup-report`, `+meeting-prep`, `+weekly-digest` (read-only aggregation)
+
+### Events/Subscriptions
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws events +subscribe\|+renew` | Subscription helpers | Creates persistent push notification channels |
+| `gws events subscriptions create\|patch\|delete` | Subscription API mutations | Push notification channel management |
+
+### Classroom (Entire service blocked)
+
+All `gws classroom` subcommands are blocked. No read or write access.
+
+### Meet (Mutations blocked)
+
+| Pattern | Matches | Why Blocked |
+|---------|---------|-------------|
+| `gws meet spaces create\|patch\|endActiveConference` | Space mutations | Creating/modifying meeting spaces |
+
+## Network Egress Analysis
+
+All hardcoded URLs in the gws CLI point exclusively to `*.googleapis.com`:
+
+| Component | Destination |
+|-----------|-------------|
+| Discovery fetch | `www.googleapis.com` |
+| API requests | `{service}.googleapis.com` |
+| OAuth token exchange | `oauth2.googleapis.com` |
+| Model Armor | `modelarmor.{region}.rep.googleapis.com` |
+
+No non-Google endpoints exist in source. Discovery Document `rootUrl`/`baseUrl` fields are fetched over HTTPS from hardcoded `googleapis.com` URLs. Exploitation requires MITM with a trusted CA.
+
+## Credential Security
+
+- Credentials encrypted at rest with AES-256-GCM, unique 12-byte nonce per encryption
+- Encryption key stored in OS keyring (primary) with encrypted file fallback
+- Key material zeroed after use via `zeroize` crate
+- Unix file permissions: 0600 for credential files, 0700 for directories
+- OAuth redirect URI hardcoded to `http://localhost`
+- `gws auth export` masks secrets by default (requires `--unmasked` for full output)
+
+## Dependency Supply Chain
+
+- 353 transitive dependencies, all from crates.io (zero git dependencies)
+- TLS: rustls (pure Rust) with system root certificate validation
+- Crypto: AES-256-GCM via RustCrypto, key derivation via `ring`
+- Auth: `yup-oauth2` (Google-backed)
+- No dependency phones home or includes telemetry
+
+## Known Limitations
+
+Same caveats as general command blocking (see [blocked-commands-reference.md](blocked-commands-reference.md)):
+
+- **Regex-based** — can be bypassed with creative quoting, variable expansion, or indirect invocation
+- **Single-command scope** — cannot track state across multiple commands (e.g., alias setup then invocation)
+- **CLI layer only** — direct API calls via `curl` to googleapis.com are not caught by these patterns
+- **Heredoc stripping** — commands inside heredoc bodies are intentionally not checked (avoids false positives)
+- **No argument inspection** — patterns match command structure, not argument values (e.g., cannot distinguish internal vs external email recipients)
+
+## See Also
+
+- [blocked-commands-reference.md](blocked-commands-reference.md) — General command blocking reference
+- [block-commands-design.md](block-commands-design.md) — Design decisions and architecture

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -22,6 +22,9 @@ Blocked categories:
            cipher /w, Remove-Item -Recurse, reg delete
   PowerShell: Format-Volume, Clear-Disk, Remove-Partition
   Cross-platform: curl/wget piped to sh/bash (presplit)
+  GWS CLI: Gmail, Calendar, Chat (all mutations), Drive, Sheets, Tasks,
+           Keep, Forms (writes), Classroom (all), Meet (mutations),
+           Workflow/Events (egress helpers)
 """
 
 import json
@@ -145,6 +148,150 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bFormat-Volume\b", re.IGNORECASE), "Format-Volume"),
     (re.compile(r"\bClear-Disk\b", re.IGNORECASE), "Clear-Disk"),
     (re.compile(r"\bRemove-Partition\b", re.IGNORECASE), "Remove-Partition"),
+    # GWS CLI mutation blocking (defense-in-depth alongside OAuth scope control)
+    # Gmail: NEVER allow mutations — primary email egress risk
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+gmail\s+"
+            r"\+(?:send|reply|reply-all|forward|watch)\b"
+        ),
+        "gws gmail (helper mutation)",
+    ),
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+gmail\s+"
+            r"(?:messages\s+(?:send|import|insert|delete|batchDelete"
+            r"|trash|untrash|modify|batchModify)"
+            r"|drafts\s+(?:create|send|update|delete)"
+            r"|labels\s+(?:create|delete|patch|update)"
+            r"|settings\s+.*\b(?:create|update|delete|patch)"
+            r"|watch|stop)\b"
+        ),
+        "gws gmail (API mutation)",
+    ),
+    # Calendar: NEVER allow mutations — external meeting invites
+    (
+        re.compile(rf"{_ENV}{_PATH}gws{_EXE}\s+calendar\s+\+insert\b"),
+        "gws calendar (helper mutation)",
+    ),
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+calendar\s+"
+            r"(?:events\s+(?:insert|delete|import|move|patch|quickAdd|update|watch)"
+            r"|acl\s+(?:insert|delete|patch|update)"
+            r"|calendars\s+(?:insert|delete|patch|update|clear)"
+            r"|calendarList\s+(?:insert|delete|patch|update)"
+            r"|channels\s+stop)\b"
+        ),
+        "gws calendar (API mutation)",
+    ),
+    # Chat: NEVER — all egress blocked
+    (
+        re.compile(rf"{_ENV}{_PATH}gws{_EXE}\s+chat\s+\+send\b"),
+        "gws chat (helper egress)",
+    ),
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+chat\s+"
+            r"(?:spaces\s+(?:create|setup|patch|delete|completeImport)"
+            r"|messages\s+(?:create|delete|patch|update)"
+            r"|members\s+(?:create|delete)"
+            r"|customEmojis\s+(?:create|delete))\b"
+        ),
+        "gws chat (API mutation)",
+    ),
+    # Drive: block all file mutations and permissions
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+drive\s+"
+            r"(?:\+upload"
+            r"|files\s+(?:create|copy|delete|update|emptyTrash|modifyLabels)"
+            r"|permissions\s+(?:create|update|delete)"
+            r"|comments\s+(?:create|update|delete)"
+            r"|replies\s+(?:create|update|delete)"
+            r"|drives\s+(?:create|delete|update|hide|unhide)"
+            r"|channels\s+stop)\b"
+        ),
+        "gws drive (mutation)",
+    ),
+    # Sheets: block all writes (indirect exfil via shared sheets)
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+sheets\s+"
+            r"(?:\+append"
+            r"|spreadsheets\s+(?:create|batchUpdate)"
+            r"|values\s+(?:append|update|batchUpdate|clear|batchClear"
+            r"|batchClearByDataFilter|batchUpdateByDataFilter)"
+            r"|sheets\s+copyTo)\b"
+        ),
+        "gws sheets (write)",
+    ),
+    # Tasks: block writes
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+tasks\s+"
+            r"(?:tasks\s+(?:insert|delete|patch|update|clear|move)"
+            r"|tasklists\s+(?:insert|delete|patch|update))\b"
+        ),
+        "gws tasks (write)",
+    ),
+    # Keep: block writes
+    (
+        re.compile(rf"{_ENV}{_PATH}gws{_EXE}\s+keep\s+" r"notes\s+(?:create|delete)\b"),
+        "gws keep (write)",
+    ),
+    # Forms: block writes
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+forms\s+" r"forms\s+(?:create|batchUpdate)\b"
+        ),
+        "gws forms (write)",
+    ),
+    # Docs: block writes (batch payloads obscure scope, indirect exfil via shared docs)
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+docs\s+" r"documents\s+(?:create|batchUpdate)\b"
+        ),
+        "gws docs (write)",
+    ),
+    # Slides: block writes (same rationale as Docs)
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+slides\s+"
+            r"presentations\s+(?:create|batchUpdate)\b"
+        ),
+        "gws slides (write)",
+    ),
+    # Workflow: block egress helpers only (via workflow or wf alias)
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+(?:workflow|wf)\s+"
+            r"\+(?:file-announce|email-to-task)\b"
+        ),
+        "gws workflow (egress)",
+    ),
+    # Events: block subscriptions (push notification channels)
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+events\s+"
+            r"(?:\+(?:subscribe|renew)"
+            r"|subscriptions\s+(?:create|patch|delete))\b"
+        ),
+        "gws events (subscription)",
+    ),
+    # Classroom: block entire service
+    (
+        re.compile(rf"{_ENV}{_PATH}gws{_EXE}\s+classroom\b"),
+        "gws classroom",
+    ),
+    # Meet: block mutations
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}gws{_EXE}\s+meet\s+"
+            r"spaces\s+(?:create|patch|endActiveConference)\b"
+        ),
+        "gws meet (mutation)",
+    ),
 ]
 
 

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -690,6 +690,354 @@ class TestPresplitPatterns:
         assert block_commands.check_command(command) is None
 
 
+class TestGwsGmailBlocked:
+    """Gmail mutations must be blocked — primary email egress risk."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws gmail +send", "gws gmail (helper mutation)"),
+            ("gws gmail +reply", "gws gmail (helper mutation)"),
+            ("gws gmail +reply-all", "gws gmail (helper mutation)"),
+            ("gws gmail +forward", "gws gmail (helper mutation)"),
+            ("gws gmail +watch", "gws gmail (helper mutation)"),
+            ("gws gmail messages send", "gws gmail (API mutation)"),
+            ("gws gmail messages delete", "gws gmail (API mutation)"),
+            ("gws gmail messages batchDelete", "gws gmail (API mutation)"),
+            ("gws gmail messages trash", "gws gmail (API mutation)"),
+            ("gws gmail messages modify", "gws gmail (API mutation)"),
+            ("gws gmail messages import", "gws gmail (API mutation)"),
+            ("gws gmail drafts create", "gws gmail (API mutation)"),
+            ("gws gmail drafts send", "gws gmail (API mutation)"),
+            ("gws gmail labels create", "gws gmail (API mutation)"),
+            ("gws gmail labels delete", "gws gmail (API mutation)"),
+            ("gws gmail settings sendAs create", "gws gmail (API mutation)"),
+            ("gws gmail watch", "gws gmail (API mutation)"),
+            ("gws gmail stop", "gws gmail (API mutation)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsGmailAllowed:
+    """Gmail read-only operations must be allowed."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gws gmail messages list",
+            "gws gmail messages get msg123",
+            "gws gmail labels list",
+            "gws gmail labels get label123",
+            "gws gmail drafts list",
+            "gws gmail drafts get draft123",
+        ],
+    )
+    def test_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
+class TestGwsCalendarBlocked:
+    """Calendar mutations must be blocked — external meeting invites."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws calendar +insert", "gws calendar (helper mutation)"),
+            ("gws calendar events insert", "gws calendar (API mutation)"),
+            ("gws calendar events delete", "gws calendar (API mutation)"),
+            ("gws calendar events patch", "gws calendar (API mutation)"),
+            ("gws calendar events quickAdd", "gws calendar (API mutation)"),
+            ("gws calendar events update", "gws calendar (API mutation)"),
+            ("gws calendar acl insert", "gws calendar (API mutation)"),
+            ("gws calendar calendars delete", "gws calendar (API mutation)"),
+            ("gws calendar channels stop", "gws calendar (API mutation)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsCalendarAllowed:
+    """Calendar read-only operations must be allowed."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gws calendar +agenda",
+            "gws calendar events list",
+            "gws calendar events get evt123",
+            "gws calendar events instances evt123",
+            "gws calendar calendarList list",
+        ],
+    )
+    def test_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
+class TestGwsChatBlocked:
+    """Chat egress must be blocked entirely."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws chat +send", "gws chat (helper egress)"),
+            ("gws chat spaces create", "gws chat (API mutation)"),
+            ("gws chat messages create", "gws chat (API mutation)"),
+            ("gws chat members create", "gws chat (API mutation)"),
+            ("gws chat customEmojis create", "gws chat (API mutation)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsDriveBlocked:
+    """Drive file mutations and permissions must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws drive +upload", "gws drive (mutation)"),
+            ("gws drive files create", "gws drive (mutation)"),
+            ("gws drive files copy", "gws drive (mutation)"),
+            ("gws drive files delete", "gws drive (mutation)"),
+            ("gws drive files update", "gws drive (mutation)"),
+            ("gws drive files emptyTrash", "gws drive (mutation)"),
+            ("gws drive files modifyLabels", "gws drive (mutation)"),
+            ("gws drive permissions create", "gws drive (mutation)"),
+            ("gws drive permissions delete", "gws drive (mutation)"),
+            ("gws drive comments create", "gws drive (mutation)"),
+            ("gws drive channels stop", "gws drive (mutation)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsDriveAllowed:
+    """Drive read-only operations must be allowed."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gws drive files list",
+            "gws drive files get file123",
+            "gws drive +download",
+            "gws drive +export",
+            "gws drive permissions list",
+        ],
+    )
+    def test_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
+class TestGwsSheetsBlocked:
+    """Sheets writes must be blocked — indirect exfil via shared sheets."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws sheets +append", "gws sheets (write)"),
+            ("gws sheets values append", "gws sheets (write)"),
+            ("gws sheets values update", "gws sheets (write)"),
+            ("gws sheets values batchUpdate", "gws sheets (write)"),
+            ("gws sheets values clear", "gws sheets (write)"),
+            ("gws sheets spreadsheets create", "gws sheets (write)"),
+            ("gws sheets spreadsheets batchUpdate", "gws sheets (write)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsSheetsAllowed:
+    """Sheets read-only operations must be allowed."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gws sheets +read",
+            "gws sheets values get",
+            "gws sheets values batchGet",
+            "gws sheets spreadsheets get",
+        ],
+    )
+    def test_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
+class TestGwsTasksBlocked:
+    """Tasks writes must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws tasks tasks insert", "gws tasks (write)"),
+            ("gws tasks tasks delete", "gws tasks (write)"),
+            ("gws tasks tasks patch", "gws tasks (write)"),
+            ("gws tasks tasklists insert", "gws tasks (write)"),
+            ("gws tasks tasklists delete", "gws tasks (write)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsKeepBlocked:
+    """Keep writes must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws keep notes create", "gws keep (write)"),
+            ("gws keep notes delete", "gws keep (write)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsFormsBlocked:
+    """Forms writes must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws forms forms create", "gws forms (write)"),
+            ("gws forms forms batchUpdate", "gws forms (write)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsWorkflowBlocked:
+    """Workflow egress helpers must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws workflow +file-announce", "gws workflow (egress)"),
+            ("gws wf +email-to-task", "gws workflow (egress)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsWorkflowAllowed:
+    """Workflow non-egress helpers must be allowed."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gws workflow +standup-report",
+            "gws workflow +meeting-prep",
+            "gws wf +weekly-digest",
+        ],
+    )
+    def test_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
+class TestGwsDocsBlocked:
+    """Docs writes must be blocked — batch payloads obscure scope."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws docs documents create", "gws docs (write)"),
+            ("gws docs documents batchUpdate", "gws docs (write)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    def test_read_allowed(self) -> None:
+        assert block_commands.check_command("gws docs documents get") is None
+
+
+class TestGwsSlidesBlocked:
+    """Slides writes must be blocked — same rationale as Docs."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws slides presentations create", "gws slides (write)"),
+            ("gws slides presentations batchUpdate", "gws slides (write)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    def test_read_allowed(self) -> None:
+        assert block_commands.check_command("gws slides presentations get") is None
+
+
+class TestGwsEventsBlocked:
+    """Events/subscriptions must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws events +subscribe", "gws events (subscription)"),
+            ("gws events +renew", "gws events (subscription)"),
+            ("gws events subscriptions create", "gws events (subscription)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsClassroomBlocked:
+    """Classroom — entire service blocked."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gws classroom courses list",
+            "gws classroom students list",
+        ],
+    )
+    def test_blocked(self, command: str) -> None:
+        assert block_commands.check_command(command) == "gws classroom"
+
+
+class TestGwsMeetBlocked:
+    """Meet mutations must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("gws meet spaces create", "gws meet (mutation)"),
+            ("gws meet spaces patch", "gws meet (mutation)"),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
+class TestGwsPathVariants:
+    """GWS commands with path prefix, .exe suffix, env prefix."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("/usr/local/bin/gws gmail +send", "gws gmail (helper mutation)"),
+            ("gws.exe gmail messages send", "gws gmail (API mutation)"),
+            ("env gws gmail +send", "gws gmail (helper mutation)"),
+            (
+                "env -i /usr/bin/gws gmail messages delete",
+                "gws gmail (API mutation)",
+            ),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+
 class TestMain:
     def test_blocked_command_exits_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
         data = {"tool_input": {"command": "git push origin main"}}


### PR DESCRIPTION
- Block Gmail, Calendar, Chat mutations (NEVER — primary egress vectors)
- Block Drive, Sheets, Docs, Slides, Tasks, Keep, Forms writes
- Block Classroom entirely, Meet mutations, Events subscriptions
- Block Workflow egress helpers (+file-announce, +email-to-task)
- Add comprehensive test coverage for all GWS patterns
- Add gws-cli-blocking.md with threat model and security analysis
- Update blocked-commands-reference.md with GWS section

Assisted-by: Claude Code (Claude Opus 4.6)