### PR TITLE
Remove notify hooks from settings

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -14,17 +14,6 @@
     "superpowers@claude-plugins-official": true
   },
   "hooks": {
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "command": "python3 ~/.claude/my-claude-stuff/scripts/notify.py",
-            "type": "command"
-          }
-        ],
-        "matcher": ""
-      }
-    ],
     "PreToolUse": [
       {
         "hooks": [
@@ -46,15 +35,6 @@
       }
     ],
     "Stop": [
-      {
-        "hooks": [
-          {
-            "command": "python3 ~/.claude/my-claude-stuff/scripts/notify.py",
-            "type": "command"
-          }
-        ],
-        "matcher": ""
-      },
       {
         "hooks": [
           {


### PR DESCRIPTION
- Remove Notification hook event entirely
- Remove notify.py hook from Stop event

Assisted-by: Claude Code (claude-opus-4-6)