### PR TITLE
Generalize cost tracking to all sessions and add project cost

### DIFF
--- a/scripts/session_tracker.py
+++ b/scripts/session_tracker.py
@@ -17,9 +17,11 @@ Layout:
 import json
 import re
 from datetime import date
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 DEFAULT_DIR = Path.home() / ".claude" / "session-tracker"
+SESSION_FILE_SUFFIX = ".json"
+WORKTREE_DIR_NAME = "git-worktrees"
 
 
 def track_session(data, base_dir=DEFAULT_DIR):
@@ -35,11 +37,24 @@ def track_session(data, base_dir=DEFAULT_DIR):
     today_dir = Path(base_dir) / date.today().isoformat()
     try:
         today_dir.mkdir(parents=True, exist_ok=True)
-        session_file = today_dir / f"{session_id}.json"
+        session_file = today_dir / f"{session_id}{SESSION_FILE_SUFFIX}"
         with open(session_file, "w", encoding="utf-8") as fh:
             json.dump(data, fh)
     except OSError:
         pass
+
+
+def _normalize_project_dir(path):
+    """Normalize project_dir by stripping WORKTREE_DIR_NAME/<name> suffix.
+
+    If path contains the worktree directory, return the grandparent.
+    This ensures worktree sessions roll up to the main project.
+    """
+    parts = PurePosixPath(path).parts
+    for i, part in enumerate(parts):
+        if part == WORKTREE_DIR_NAME and i + 1 < len(parts):
+            return str(PurePosixPath(*parts[:i]))
+    return path
 
 
 def get_daily_cost(base_dir=DEFAULT_DIR):
@@ -50,7 +65,7 @@ def get_daily_cost(base_dir=DEFAULT_DIR):
 
     total = 0.0
     for session_file in today_dir.iterdir():
-        if not session_file.suffix == ".json":
+        if session_file.suffix != SESSION_FILE_SUFFIX:
             continue
         try:
             with open(session_file, "r", encoding="utf-8") as fh:
@@ -58,4 +73,35 @@ def get_daily_cost(base_dir=DEFAULT_DIR):
             total += (data.get("cost") or {}).get("total_cost_usd", 0.0)
         except (json.JSONDecodeError, OSError):
             continue
+    return total
+
+
+def get_project_cost(project_dir, base_dir=DEFAULT_DIR):
+    """Sum cost.total_cost_usd across ALL dates for sessions matching project_dir.
+
+    Normalizes project_dir (stripping git-worktrees suffixes) before comparison.
+    """
+    base = Path(base_dir)
+    if not base.is_dir():
+        return 0.0
+
+    normalized_query = _normalize_project_dir(project_dir)
+    total = 0.0
+
+    for date_dir in base.iterdir():
+        if not date_dir.is_dir():
+            continue
+        for session_file in date_dir.iterdir():
+            if session_file.suffix != SESSION_FILE_SUFFIX:
+                continue
+            try:
+                with open(session_file, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                session_project = (data.get("workspace") or {}).get("project_dir")
+                if not session_project:
+                    continue
+                if _normalize_project_dir(session_project) == normalized_query:
+                    total += (data.get("cost") or {}).get("total_cost_usd", 0.0)
+            except (json.JSONDecodeError, OSError):
+                continue
     return total

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -14,13 +14,12 @@ Freshness indicator shows age and fetch status:
   (2m)  = data is 2 minutes old, last fetch succeeded
   (!5m) = data is 5 minutes old, last fetch failed
 
-Session cost (Vertex only) from Claude Code stdin.
+Session cost from Claude Code stdin (cost.total_cost_usd).
 """
 
 import json
 import logging
 import logging.handlers
-import os
 import sys
 import time
 import urllib.request
@@ -282,21 +281,32 @@ def main():
         else:
             parts.append(f"({age_str})")
 
-    is_vertex = bool(os.environ.get("CLAUDE_CODE_USE_VERTEX"))
+    # When invoked directly (python3 path/to/statusline.py), the parent
+    # of scripts/ must be on sys.path for the package import to work.
+    _scripts_parent = str(Path(__file__).resolve().parent.parent)
+    if _scripts_parent not in sys.path:
+        sys.path.insert(0, _scripts_parent)
+    from scripts.session_tracker import get_daily_cost, get_project_cost, track_session
 
-    if is_vertex:
-        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-        from scripts.session_tracker import get_daily_cost, track_session
+    track_session(data)
+    cost = (data.get("cost") or {}).get("total_cost_usd")
+    parts.append(f"Session: ${cost:.2f}" if cost is not None else "Session: $0.00")
+    daily = get_daily_cost()
+    parts.append(f"Today: ${daily:.2f}")
 
-        track_session(data)
-        cost = (data.get("cost") or {}).get("total_cost_usd")
-        parts.append(f"Session: ${cost:.2f}" if cost is not None else "Session: $0.00")
-        daily = get_daily_cost()
-        parts.append(f"Today: ${daily:.2f}")
+    project_dir = (data.get("workspace") or {}).get("project_dir")
+    if project_dir:
+        proj_cost = get_project_cost(project_dir)
+        parts.append(f"Project: ${proj_cost:.2f}")
 
     parts.append(f"Model: {model}")
     print(" | ".join(parts))
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        _configure_logging()
+        logger.exception("statusline crashed")
+        print(f"{ANSI_RED}!ERR check {LOG_FILE}{ANSI_RESET}")

--- a/tests/test_session_tracker.py
+++ b/tests/test_session_tracker.py
@@ -7,16 +7,24 @@ from datetime import date
 
 import pytest
 
-from scripts.session_tracker import get_daily_cost, track_session
+from scripts.session_tracker import (
+    _normalize_project_dir,
+    get_daily_cost,
+    get_project_cost,
+    track_session,
+)
 
 
-def _make_session_data(session_id="abc-123", cost_usd=1.50):
-    return {
+def _make_session_data(session_id="abc-123", cost_usd=1.50, project_dir=None):
+    data = {
         "session_id": session_id,
         "model": {"id": "claude-opus-4-6", "display_name": "Opus 4.6"},
         "cost": {"total_cost_usd": cost_usd},
         "context_window": {"used_percentage": 10},
     }
+    if project_dir is not None:
+        data["workspace"] = {"project_dir": project_dir}
+    return data
 
 
 class TestTrackSession:
@@ -146,3 +154,122 @@ class TestGetDailyCost:
 
         total = get_daily_cost(base_dir=tmp_path)
         assert total == pytest.approx(2.00)
+
+
+class TestNormalizeProjectDir:
+    def test_plain_path_unchanged(self):
+        path = "/home/user/source/myproject"
+        assert _normalize_project_dir(path) == path
+
+    def test_strips_worktree_suffix(self):
+        wt = "/home/user/source/myproject/git-worktrees/abc123"
+        assert _normalize_project_dir(wt) == "/home/user/source/myproject"
+
+    def test_no_worktree_name_unchanged(self):
+        # git-worktrees at the end without a child stays as-is
+        path = "/home/user/git-worktrees"
+        assert _normalize_project_dir(path) == path
+
+
+class TestGetProjectCost:
+    def test_sums_across_dates(self, tmp_path):
+        # Create sessions in multiple date dirs
+        d1 = tmp_path / "2026-03-18"
+        d1.mkdir()
+        d2 = tmp_path / "2026-03-19"
+        d2.mkdir()
+
+        proj = "/home/user/myproject"
+        (d1 / "s1.json").write_text(
+            json.dumps(
+                _make_session_data(session_id="s1", cost_usd=2.00, project_dir=proj)
+            )
+        )
+        (d2 / "s2.json").write_text(
+            json.dumps(
+                _make_session_data(session_id="s2", cost_usd=3.50, project_dir=proj)
+            )
+        )
+
+        total = get_project_cost(proj, base_dir=tmp_path)
+        assert total == pytest.approx(5.50)
+
+    def test_filters_by_project_dir(self, tmp_path):
+        d = tmp_path / "2026-03-18"
+        d.mkdir()
+
+        (d / "s1.json").write_text(
+            json.dumps(
+                _make_session_data(
+                    session_id="s1", cost_usd=2.00, project_dir="/proj/a"
+                )
+            )
+        )
+        (d / "s2.json").write_text(
+            json.dumps(
+                _make_session_data(
+                    session_id="s2", cost_usd=5.00, project_dir="/proj/b"
+                )
+            )
+        )
+
+        assert get_project_cost("/proj/a", base_dir=tmp_path) == pytest.approx(2.00)
+        assert get_project_cost("/proj/b", base_dir=tmp_path) == pytest.approx(5.00)
+
+    def test_worktree_rollup(self, tmp_path):
+        d = tmp_path / "2026-03-18"
+        d.mkdir()
+
+        (d / "s1.json").write_text(
+            json.dumps(
+                _make_session_data(
+                    session_id="s1",
+                    cost_usd=4.00,
+                    project_dir="/home/user/myproject/git-worktrees/1234",
+                )
+            )
+        )
+        (d / "s2.json").write_text(
+            json.dumps(
+                _make_session_data(
+                    session_id="s2",
+                    cost_usd=1.00,
+                    project_dir="/home/user/myproject",
+                )
+            )
+        )
+
+        total = get_project_cost("/home/user/myproject", base_dir=tmp_path)
+        assert total == pytest.approx(5.00)
+
+    def test_returns_zero_for_unknown_project(self, tmp_path):
+        d = tmp_path / "2026-03-18"
+        d.mkdir()
+        (d / "s1.json").write_text(
+            json.dumps(
+                _make_session_data(
+                    session_id="s1", cost_usd=2.00, project_dir="/proj/a"
+                )
+            )
+        )
+
+        assert get_project_cost("/proj/unknown", base_dir=tmp_path) == 0.0
+
+    def test_handles_missing_workspace(self, tmp_path):
+        d = tmp_path / "2026-03-18"
+        d.mkdir()
+
+        # Session without workspace field
+        (d / "s1.json").write_text(
+            json.dumps(_make_session_data(session_id="s1", cost_usd=2.00))
+        )
+        # Session with workspace
+        (d / "s2.json").write_text(
+            json.dumps(
+                _make_session_data(
+                    session_id="s2", cost_usd=3.00, project_dir="/proj/a"
+                )
+            )
+        )
+
+        assert get_project_cost("/proj/a", base_dir=tmp_path) == pytest.approx(3.00)

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -39,7 +39,6 @@ def isolate_paths(tmp_path, monkeypatch):
     creds_file = tmp_path / "credentials.json"
     monkeypatch.setattr(statusline, "USAGE_CACHE_FILE", cache_file)
     monkeypatch.setattr(statusline, "CREDENTIALS_FILE", creds_file)
-    monkeypatch.delenv("CLAUDE_CODE_USE_VERTEX", raising=False)
     return tmp_path, cache_file, creds_file
 
 
@@ -579,12 +578,12 @@ class TestMain:
         output = self._run_main(monkeypatch, capsys, {})
         assert "Model: Claude" in output
 
-    def test_vertex_mode(self, monkeypatch, capsys):
-        monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+    def test_cost_display(self, monkeypatch, capsys, tmp_path):
         data = {
             **SAMPLE_STDIN,
             "cost": {"total_cost_usd": 1.50},
             "session_id": "test-session",
+            "workspace": {"project_dir": str(tmp_path)},
         }
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
         monkeypatch.setattr(
@@ -598,6 +597,7 @@ class TestMain:
         mock_tracker = types.ModuleType("session_tracker")
         mock_tracker.track_session = lambda data: None
         mock_tracker.get_daily_cost = lambda: 5.25
+        mock_tracker.get_project_cost = lambda project_dir: 42.00
         monkeypatch.setitem(
             __import__("sys").modules,
             "scripts.session_tracker",
@@ -608,9 +608,9 @@ class TestMain:
         output = capsys.readouterr().out.strip()
         assert "Session: $1.50" in output
         assert "Today: $5.25" in output
+        assert "Project: $42.00" in output
 
-    def test_no_cost_in_vertex(self, monkeypatch, capsys):
-        monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+    def test_no_cost_shows_zero(self, monkeypatch, capsys):
         monkeypatch.setattr(
             "sys.stdin",
             io.StringIO(json.dumps(SAMPLE_STDIN)),
@@ -626,6 +626,7 @@ class TestMain:
         mock_tracker = types.ModuleType("session_tracker")
         mock_tracker.track_session = lambda data: None
         mock_tracker.get_daily_cost = lambda: 0.0
+        mock_tracker.get_project_cost = lambda project_dir: 0.0
         monkeypatch.setitem(
             __import__("sys").modules,
             "scripts.session_tracker",
@@ -636,15 +637,35 @@ class TestMain:
         output = capsys.readouterr().out.strip()
         assert "Session: $0.00" in output
 
-    def test_no_session_cost_without_vertex(self, monkeypatch, capsys):
-        output = self._run_main(
-            monkeypatch,
-            capsys,
-            SAMPLE_STDIN,
-            usage=SAMPLE_USAGE_RESPONSE,
+    def test_project_cost_displayed(self, monkeypatch, capsys, tmp_path):
+        data = {
+            **SAMPLE_STDIN,
+            "cost": {"total_cost_usd": 0.50},
+            "session_id": "s1",
+            "workspace": {"project_dir": str(tmp_path)},
+        }
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
+        monkeypatch.setattr(
+            statusline,
+            "get_usage",
+            lambda: (None, 0, False),
         )
-        assert "Session:" not in output
-        assert "Today:" not in output
+
+        import types
+
+        mock_tracker = types.ModuleType("session_tracker")
+        mock_tracker.track_session = lambda data: None
+        mock_tracker.get_daily_cost = lambda: 1.00
+        mock_tracker.get_project_cost = lambda project_dir: 245.00
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "scripts.session_tracker",
+            mock_tracker,
+        )
+
+        statusline.main()
+        output = capsys.readouterr().out.strip()
+        assert "Project: $245.00" in output
 
     def test_null_usage_fields(self, monkeypatch, capsys):
         usage = {


### PR DESCRIPTION
- Remove Vertex-only gate from cost tracking — session/daily cost now shown for all backends
- Add get_project_cost() to sum costs across all dates for a given project_dir
- Add worktree rollup via _normalize_project_dir() so worktree sessions roll up to main project
- Extract magic strings into constants (SESSION_FILE_SUFFIX, WORKTREE_DIR_NAME)
- Add top-level exception handler with red error indicator and log path
- Fix sys.path setup for deployed script (removed during Vertex gate cleanup)
- Remove unused os import

Assisted-by: Claude Code (Claude Opus 4.6)