### PR TITLE
Update voice skill permission path to use shared venvs directory

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -70,7 +70,7 @@
   },
   "permissions": {
     "allow": [
-      "Bash(*.claude/skills/voice/.venv/*/python* *.claude/skills/voice/scripts/voice.py*)",
+      "Bash(*.claude/venvs/*/python* *.claude/skills/voice/scripts/voice.py*)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
       "Bash(gh search:*)",


### PR DESCRIPTION
- Change Bash permission glob from .claude/skills/voice/.venv/ to .claude/venvs/

Assisted-by: Claude Code (Claude Opus 4.6)