### PR TITLE
Reset backoff after 6h gap and add SemVer versioning rule

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -33,6 +33,7 @@
 - Descriptive variable names — `unit_of_measure` not `unit`; don't repeat context from containing object/class
 - Fix linter errors if you introduce them
 - Create dependency management files when building from scratch
+- **Versioning**: new projects start at `0.1.0`, follow [SemVer](https://semver.org/). User decides when to bump.
 
 ## Reviews
 - Capture reviews in `Review-<short context>.md` in the project root

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -210,6 +210,8 @@ def _write_cache(cache_dict):
 
 
 MAX_COOLDOWN_SECONDS = 3600
+# If no attempt in this window, assume stale failure (sleep/resume) and retry
+STALE_FAILURE_SECONDS = 21600  # 6 hours
 
 
 def get_usage():
@@ -224,11 +226,18 @@ def get_usage():
 
         # Stale — check if we should skip fetch due to backoff cooldown
         failures = cached.get("consecutive_failures", 0)
+        since_last_attempt = now - cached.get("last_attempt_at", 0)
+        # Long gap (sleep/resume) — reset backoff and retry immediately
+        if failures > 0 and since_last_attempt >= STALE_FAILURE_SECONDS:
+            logger.info(
+                "Stale failure: %.0fs since last attempt, resetting backoff",
+                since_last_attempt,
+            )
+            failures = 0
         if failures > 0:
             cooldown = min(
                 USAGE_CACHE_TTL_SECONDS * (2**failures), MAX_COOLDOWN_SECONDS
             )
-            since_last_attempt = now - cached.get("last_attempt_at", 0)
             if since_last_attempt < cooldown:
                 logger.info(
                     "Backoff: skipping fetch, %d consecutive failures, "

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -416,6 +416,54 @@ class TestGetUsage:
         assert len(fetch_called) == 1
         assert stale is False
 
+    def test_stale_failure_resets_backoff(self, isolate_paths, monkeypatch):
+        """If last attempt was >6h ago, reset backoff and retry immediately."""
+        _, cache_file, _ = isolate_paths
+        now = time.time()
+        cached = _make_cache(
+            {"stale": True},
+            now - 30000,
+            last_attempt_at=now - 22000,  # >6h ago
+            consecutive_failures=5,
+        )
+        cache_file.write_text(json.dumps(cached), encoding="utf-8")
+
+        fetch_called = []
+        monkeypatch.setattr(
+            statusline,
+            "fetch_usage",
+            lambda: fetch_called.append(1) or SAMPLE_USAGE_RESPONSE,
+        )
+
+        usage, age, stale = statusline.get_usage()
+        assert len(fetch_called) == 1
+        assert stale is False
+
+    def test_stale_failure_within_window_still_backs_off(
+        self, isolate_paths, monkeypatch
+    ):
+        """If last attempt was <6h ago, normal backoff still applies."""
+        _, cache_file, _ = isolate_paths
+        now = time.time()
+        cached = _make_cache(
+            {"stale": True},
+            now - 10000,
+            last_attempt_at=now - 10,  # 10s ago, well within 6h
+            consecutive_failures=3,
+        )
+        cache_file.write_text(json.dumps(cached), encoding="utf-8")
+
+        fetch_called = []
+        monkeypatch.setattr(
+            statusline,
+            "fetch_usage",
+            lambda: fetch_called.append(1) or SAMPLE_USAGE_RESPONSE,
+        )
+
+        usage, age, stale = statusline.get_usage()
+        assert len(fetch_called) == 0
+        assert stale is True
+
     def test_no_cache_no_fetch(self, monkeypatch):
         monkeypatch.setattr(statusline, "fetch_usage", lambda: None)
         usage, age, stale = statusline.get_usage()


### PR DESCRIPTION
- Reset usage API backoff when last attempt was >6h ago (sleep/resume)
- Add SemVer versioning rule to CLAUDE.md (start at 0.1.0, user bumps)

Assisted-by: Claude Code (Claude Opus 4.6)