### PR TITLE
Allow read-only gh api graphql queries in block_commands

### DIFF
--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -34,7 +34,8 @@ Blocked categories:
   GWS CLI: Gmail, Calendar, Chat (all mutations), Drive, Sheets, Tasks,
            Keep, Forms, Docs, Slides (writes), Classroom, Workflow (all),
            Meet (mutations), Events (subscriptions)
-  GitHub CLI: gh api (mutation indicators: non-GET method, field/body flags),
+  GitHub CLI: gh api (mutation indicators: non-GET method, field/body flags;
+              exception: gh api graphql query operations are read-only),
               issue/pr/repo/release/gist/label/project (mutations),
               run/workflow (mutations), secret/variable (mutations),
               deploy-key/ssh-key/gpg-key (mutations),
@@ -74,6 +75,12 @@ PRESPLIT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "pipe-to-shell",
     ),
 ]
+
+# Detect `gh api graphql` commands (with optional path/env/exe prefixes)
+_GH_API_GRAPHQL_RE = re.compile(rf"{_ENV}{_PATH}gh{_EXE}\s+api\s+graphql\b")
+
+# Detect GraphQL mutation operations within -f query='...' value
+_GRAPHQL_MUTATION_RE = re.compile(r"\bmutation\b")
 
 BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # git -C: unnecessary when already in the target directory; use plain git
@@ -570,6 +577,14 @@ def check_command(command: str) -> str | None:
     for pattern, name in PRESPLIT_PATTERNS:
         if pattern.search(check_text):
             return name
+
+    # 3b. GraphQL query exception: gh api graphql with -f/-F flags is only
+    # mutating if the query contains a 'mutation' operation.  Query operations
+    # (explicit 'query' keyword or shorthand '{...}') are read-only.
+    if _GH_API_GRAPHQL_RE.search(check_text):
+        if _GRAPHQL_MUTATION_RE.search(check_text):
+            return "gh api (mutation)"
+        return None
 
     # 4. Split into chain segments
     segments = split_command_chain(check_text)

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -1270,7 +1270,7 @@ class TestGhApiMutationsBlocked:
             "gh api -X DELETE /repos/owner/repo/issues/1",
             "gh api --method POST /repos/owner/repo/issues",
             "gh api --method DELETE /repos/owner/repo/issues/1",
-            "gh api graphql -f query='{viewer{login}}'",
+            "gh api graphql -f query='mutation { createIssue(input: {}) { id } }'",
             "gh api /repos/owner/repo/issues -f title=test -f body=test",
             "gh api /repos/owner/repo/issues -F body=@file.md",
             "gh api /repos/owner/repo/issues --field title=test",
@@ -1307,6 +1307,64 @@ class TestGhApiReadAllowed:
     )
     def test_allowed(self, command: str) -> None:
         assert block_commands.check_command(command) is None
+
+
+class TestGhApiGraphqlQueryAllowed:
+    """gh api graphql with query operations must be allowed."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Shorthand query (no explicit query keyword)
+            "gh api graphql -f query='{viewer{login}}'",
+            # Explicit query keyword
+            "gh api graphql -f query='query { viewer { login } }'",
+            # Query with variables using -f and -F flags
+            (
+                "gh api graphql -f query='"
+                "query($owner: String!, $repo: String!, $pr: Int!) {"
+                "  repository(owner: $owner, name: $repo) {"
+                "    pullRequest(number: $pr) {"
+                "      reviewThreads(first: 100) {"
+                "        nodes { isResolved }"
+                "      }"
+                "    }"
+                "  }"
+                "}' -f owner='ansible' -f repo='handbook' -F pr=1301"
+            ),
+            # With path prefix
+            "/usr/bin/gh api graphql -f query='{ viewer { login } }'",
+            # With .exe suffix
+            "gh.exe api graphql -f query='{ viewer { login } }'",
+            # With env prefix
+            "env gh api graphql -f query='{ viewer { login } }'",
+        ],
+    )
+    def test_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
+class TestGhApiGraphqlMutationBlocked:
+    """gh api graphql with mutation operations must be blocked."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api graphql -f query='mutation { createIssue(input: {}) { id } }'",
+            (
+                "gh api graphql -f query='mutation CreateIssue"
+                "($input: CreateIssueInput!)"
+                " { createIssue(input: $input) { issue { id } } }'"
+            ),
+            (
+                "/usr/bin/gh api graphql"
+                " -f query='mutation { deleteIssue(input: {})"
+                " { id } }'"
+            ),
+        ],
+    )
+    def test_blocked(self, command: str) -> None:
+        assert block_commands.check_command(command) == "gh api (mutation)"
 
 
 class TestGhIssueMutationsBlocked:


### PR DESCRIPTION
- Add GraphQL exception before generic gh api mutation check
- Query operations (explicit or shorthand) bypass -f/-F flag blocking
- GraphQL mutations still correctly blocked
- Update docstring to document the exception

Assisted-by: Claude Code (Claude Opus 4.6)