### PR TITLE
Allow git -C for git-worktrees/ paths in block_commands

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Restrictions
 - **Never execute**: `git push`, `sudo`, or `su`
+- **`git -C` is allowed only for `git-worktrees/` paths** (e.g., `git -C git-worktrees/my-pr/ log`) — all other `git -C` usage is blocked
 - **No commits to default branches** unless explicitly instructed
 - **Work on fork/feature branches** or current branch if specified
 - **Never use destructive data operations** (wipe DB, drop tables, destructive migrations) without explicit user approval

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -13,7 +13,8 @@ Preprocessing pipeline:
   5. Check each segment against BLOCKED_PATTERNS
 
 Blocked categories:
-  Git: -C flag (use plain git), add, push, reset, clean (except -n),
+  Git: -C flag (use plain git; exception: git-worktrees/ paths),
+       add, push, reset, clean (except -n),
        branch (destructive flags only),
        stash (except list/show), commit --amend/-a, checkout -- (discard),
        restore (except --staged), rebase, filter-branch, filter-repo,
@@ -84,8 +85,9 @@ _GRAPHQL_MUTATION_RE = re.compile(r"\bmutation\b")
 
 BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # git -C: unnecessary when already in the target directory; use plain git
+    # Exception: git -C <path>/git-worktrees/<worktree>/ is allowed for local PR review
     (
-        re.compile(rf"{_ENV}{_PATH}git{_EXE}\s+-C\b"),
+        re.compile(rf"{_ENV}{_PATH}git{_EXE}\s+-C\s+(?!\S*git-worktrees/)"),
         "git -C (you are already in the repo directory — use git without -C)",
     ),
     (re.compile(rf"{_ENV}{_PATH}git{_EXE}{_FLAGS}\s+add\b"), "git add"),

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -110,6 +110,19 @@ class TestCheckCommand:
         assert result is not None
         assert "git -C" in result
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git -C git-worktrees/my-pr/ status",
+            "git -C ./git-worktrees/my-pr/ log --oneline",
+            "git -C /home/user/repo/git-worktrees/pr-123/ diff",
+            "/usr/bin/git -C git-worktrees/feature-branch/ branch",
+            "env git -C git-worktrees/fix/ status",
+        ],
+    )
+    def test_git_dash_c_worktrees_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
     def test_su_standalone(self) -> None:
         assert block_commands.check_command("su") == "su"
         assert block_commands.check_command("su -") == "su"


### PR DESCRIPTION
- Add negative lookahead to git -C pattern to exempt paths containing git-worktrees/
- Add 5 parametrized test cases for worktree path variants
- Document the git -C worktree exception in CLAUDE.md restrictions

Assisted-by: Claude Code (Claude Opus 4.6)