### PR TITLE
Add allowlist usage feedback memory

### DIFF
--- a/claude/memory/MEMORY.md
+++ b/claude/memory/MEMORY.md
@@ -14,4 +14,5 @@
 - [Always use subagents](feedback_subagent_execution.md) — Never ask subagent vs inline, just use subagent-driven
 - [Write tests for new code](feedback_write_new_tests.md) — Write NEW tests for new functionality, don't just run existing
 - [Filter resolved PR comments](feedback_resolved_pr_comments.md) — Exclude resolved threads from interactive PR review
+- [Check allowlist first](feedback_use_allowlist.md) — Call mcp__allowlist__get_allowed_permissions before ANY tool use to avoid approval prompts
 - [.claude/ not for output](feedback_claude_dir_security.md) — .claude/ is config only, never write generated content there

--- a/claude/memory/feedback_use_allowlist.md
+++ b/claude/memory/feedback_use_allowlist.md
@@ -1,0 +1,16 @@
+---
+name: Check allowlist before using tools
+description: Call mcp__allowlist__get_allowed_permissions before ANY Bash or tool use to avoid approval prompts — user has repeatedly flagged non-compliance
+type: feedback
+---
+
+Before using ANY tool that might require approval — especially Bash commands — call `mcp__allowlist__get_allowed_permissions` first to check what's already permitted. Use allowlisted commands and tool patterns whenever possible.
+
+**Why:** The user's environment is designed to minimize interactive approval prompts. Every unapproved tool call interrupts their workflow. This has been flagged repeatedly because agents consistently skip the allowlist check despite it being in CLAUDE.md.
+
+**How to apply:**
+1. At the start of a session or before your first Bash/tool call, call `mcp__allowlist__get_allowed_permissions`
+2. Prefer allowlisted command patterns (e.g., `git log *` is allowed — use it instead of a Bash call that will prompt)
+3. Do NOT pipe or chain allowlisted commands with non-allowlisted commands — `git log --oneline | head -5` will trigger approval because the full pipeline is evaluated, not just the first command. Use flags on the allowlisted command itself (e.g., `git log --oneline -5`) or use separate tool calls.
+4. When you need a command that isn't allowlisted, check if there's a dedicated tool (Read, Glob, Grep, Edit) that avoids the Bash tool entirely
+5. Only fall through to an unapproved Bash call as a last resort


### PR DESCRIPTION
- Add feedback memory reinforcing allowlist check before tool use
- Include guidance on avoiding piped commands that defeat allowlist matching

Assisted-by: Claude Code (Claude Opus 4.6)