### PR TITLE
Add no-auto-commit feedback memory

### DIFF
--- a/claude/memory/MEMORY.md
+++ b/claude/memory/MEMORY.md
@@ -16,3 +16,4 @@
 - [Filter resolved PR comments](feedback_resolved_pr_comments.md) — Exclude resolved threads from interactive PR review
 - [Check allowlist first](feedback_use_allowlist.md) — Call mcp__allowlist__get_allowed_permissions before ANY tool use to avoid approval prompts
 - [.claude/ not for output](feedback_claude_dir_security.md) — .claude/ is config only, never write generated content there
+- [No auto-commit](feedback_no_auto_commit.md) — /commit only runs on explicit user request, never automatically

--- a/claude/memory/feedback_no_auto_commit.md
+++ b/claude/memory/feedback_no_auto_commit.md
@@ -1,0 +1,19 @@
+---
+name: Never auto-invoke commit skill
+description: The /commit skill must only run when the user explicitly types /commit — never invoke it automatically after fixes, checks, or any other skill
+type: feedback
+---
+
+Never invoke the /commit skill unless the user themselves typed `/commit` as their own chat message with the leading slash. No exceptions.
+
+"Explicit user request" means: the user typed `/commit` in chat as their input. It does NOT mean:
+- The user said "commit this" or "go ahead and commit" in prose — that is NOT a /commit invocation
+- The user said "fine", "ok", "sure", "yes", "proceed", or any other affirmation — that is acknowledgment, NOT a commit request
+- Another skill finished and committing seems like a logical next step
+- Checks passed and the code looks ready
+- The assistant decides it would be helpful
+- Any interpretation of user intent that isn't the literal string `/commit`
+
+**Why:** The user was burned by the commit skill being triggered automatically after a /fix run. Committing is an explicit, deliberate decision — never assume the user wants to commit just because checks pass or code was fixed.
+
+**How to apply:** After completing any skill (/fix, /simplify, etc.) or any code changes, STOP. Do not invoke /commit. Do not suggest invoking /commit. The user will type `/commit` themselves when they are ready.


### PR DESCRIPTION
- Add feedback memory prohibiting automatic /commit skill invocation
- Only the user typing /commit triggers the skill, never inferred intent

Assisted-by: Claude Code (Claude Opus 4.6)