### PR TITLE
Add feedback memories for approved-work flow and language redaction

### DIFF
--- a/claude/memory/MEMORY.md
+++ b/claude/memory/MEMORY.md
@@ -17,3 +17,5 @@
 - [Check allowlist first](feedback_use_allowlist.md) — Call mcp__allowlist__get_allowed_permissions before ANY tool use to avoid approval prompts
 - [.claude/ not for output](feedback_claude_dir_security.md) — .claude/ is config only, never write generated content there
 - [No auto-commit](feedback_no_auto_commit.md) — /commit only runs on explicit user request, never automatically
+- [Don't stop on approved work](feedback_dont_stop_approved_work.md) — Execute approved batch of tasks continuously, don't pause for permission between them
+- [Redact strong language](feedback_redact_language.md) — Remove or *** out swear words and acronyms when quoting user in persisted files

--- a/claude/memory/feedback_dont_stop_approved_work.md
+++ b/claude/memory/feedback_dont_stop_approved_work.md
@@ -1,0 +1,11 @@
+---
+name: Don't stop for go/no-go on approved work
+description: User expects continuous execution once work is approved - don't pause for permission between tasks
+type: feedback
+---
+
+When the user has approved a set of tasks (e.g., review fixes), execute them all continuously. Do not stop between tasks to ask for permission to continue.
+
+**Why:** The user finds it frustrating when work pauses for unnecessary confirmation. They were asked twice for permission to continue already-approved work and had to tell the agent to just go.
+
+**How to apply:** After receiving approval for a batch of work, execute all tasks in sequence without pausing. Only stop if genuinely blocked or if a decision requires user input that wasn't covered in the original approval.

--- a/claude/memory/feedback_redact_language.md
+++ b/claude/memory/feedback_redact_language.md
@@ -1,0 +1,11 @@
+---
+name: Redact strong language in quotes
+description: When quoting the user in memory files or documents, remove or redact swear words and their acronyms
+type: feedback
+---
+
+When quoting the user in memory files, documents, or any persisted artifacts, redact swear words and their acronyms. Either rephrase to remove them, or replace with `***`.
+
+**Why:** Memories and documents are durable artifacts that may be read in other contexts. Keep them clean.
+
+**How to apply:** Before writing any user quote to a file, scan for profanity (including acronyms) and either rephrase the quote or replace the word with `***`.


### PR DESCRIPTION
- Add memory to execute approved task batches without pausing for permission
- Add memory to redact profanity when quoting user in persisted files

Assisted-by: Claude Code (Claude Opus 4.6)