### PR TITLE
Add python -m py_compile to allowlist

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -527,6 +527,7 @@
       "Bash(make typecheck *)",
       "Bash(make version-check *)",
       "Bash(mkdir -p /tmp/cited-research)",
+      "Bash(python -m py_compile *)",
       "Bash(wc *)",
       "Edit(~/source/standards/**)",
       "Read(/tmp/cited-research/*)",


### PR DESCRIPTION
- Allow `python -m py_compile *` for syntax checking without code execution

Assisted-by: Claude Code (Claude Opus 4.6)
