### PR TITLE
Add gws gmail users messages list to allowlist

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -396,6 +396,7 @@
       "Bash(gws gmail users history --help)",
       "Bash(gws gmail users labels --help)",
       "Bash(gws gmail users messages --help)",
+      "Bash(gws gmail users messages list *)",
       "Bash(gws gmail users settings --help)",
       "Bash(gws gmail users stop --help)",
       "Bash(gws gmail users threads --help)",


### PR DESCRIPTION
- Allow read-only Gmail message listing via gws

Assisted-by: Claude Code (Claude Opus 4.6)
