### PR TITLE
Fix hooks broken on Windows: python3 is a Store stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ VENV_DIR ?= .venv
 DATA_DIR := $(HOME)/.claude/my-claude-stuff-data
 ifeq ($(OS),Windows_NT)
     PYTHON := $(VENV_DIR)/Scripts/python.exe
+    PYTHON_BOOTSTRAP := py -3
 else
     PYTHON := $(VENV_DIR)/bin/python
+    PYTHON_BOOTSTRAP := python3
 endif
 
 $(info venv: $(VENV_DIR))
@@ -15,7 +17,7 @@ default: format lint typecheck test coverage  ## Run all checks (format, lint, t
 check: default  ## Alias for default
 
 $(PYTHON):
-	python3 -m venv $(VENV_DIR)
+	$(PYTHON_BOOTSTRAP) -m venv $(VENV_DIR)
 
 install: $(PYTHON)  ## Install package
 	$(PYTHON) -m pip install .

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -12,6 +12,7 @@ scalars from src overwrite dest.
 import argparse
 import json
 import logging
+import platform
 import shutil
 import sys
 from pathlib import Path
@@ -80,6 +81,53 @@ def reconcile_claude_md(
     return True
 
 
+def _adapt_python_command(command: str) -> str:
+    """Replace 'python3 ' with platform-appropriate bootstrap command.
+
+    Source settings.json uses 'python3' (works on Linux/macOS).
+    On Windows, 'python3' is a Microsoft Store stub; 'py -3' is correct.
+    """
+    if platform.system() != "Windows":
+        return command
+    if command.startswith("python3 "):
+        return "py -3 " + command[len("python3 ") :]
+    return command
+
+
+def _adapt_hooks(settings: dict) -> dict:
+    """Adapt hook and statusLine commands for the current platform."""
+    settings = dict(settings)
+
+    # Adapt hook commands
+    hooks = settings.get("hooks")
+    if isinstance(hooks, dict):
+        adapted_hooks = {}
+        for event, hook_list in hooks.items():
+            adapted_list = []
+            for entry in hook_list:
+                entry = dict(entry)
+                inner_hooks = entry.get("hooks", [])
+                adapted_inner = []
+                for hook in inner_hooks:
+                    hook = dict(hook)
+                    if "command" in hook:
+                        hook["command"] = _adapt_python_command(hook["command"])
+                    adapted_inner.append(hook)
+                entry["hooks"] = adapted_inner
+                adapted_list.append(entry)
+            adapted_hooks[event] = adapted_list
+        settings["hooks"] = adapted_hooks
+
+    # Adapt statusLine command
+    status_line = settings.get("statusLine")
+    if isinstance(status_line, dict) and "command" in status_line:
+        status_line = dict(status_line)
+        status_line["command"] = _adapt_python_command(status_line["command"])
+        settings["statusLine"] = status_line
+
+    return settings
+
+
 def reconcile_settings(
     src_dir: Path,
     dest_dir: Path,
@@ -102,6 +150,7 @@ def reconcile_settings(
         dest_data = {}
 
     merged = merge_settings(dest_data, src_data)
+    merged = _adapt_hooks(merged)
 
     if merged == dest_data:
         logger.info("settings.json already in sync")

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -10,6 +10,8 @@ import pytest
 from scripts.reconcile import (
     EXIT_ERROR,
     EXIT_SUCCESS,
+    _adapt_hooks,
+    _adapt_python_command,
     main,
     merge_settings,
     reconcile_claude_md,
@@ -75,6 +77,118 @@ class TestMergeSettings:
         src = {"key": "replaced"}
         result = merge_settings(dest, src)
         assert result["key"] == "replaced"
+
+
+class TestAdaptPythonCommand:
+    def test_replaces_python3_on_windows(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Windows")
+        assert _adapt_python_command("python3 ~/foo.py") == "py -3 ~/foo.py"
+
+    def test_preserves_python3_on_linux(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Linux")
+        assert _adapt_python_command("python3 ~/foo.py") == "python3 ~/foo.py"
+
+    def test_preserves_python3_on_darwin(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Darwin")
+        assert _adapt_python_command("python3 ~/foo.py") == "python3 ~/foo.py"
+
+    def test_no_change_when_no_python3_prefix(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Windows")
+        assert _adapt_python_command("node ~/foo.js") == "node ~/foo.js"
+
+    def test_only_replaces_at_start(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Windows")
+        # "python3" not at start should not be replaced
+        assert _adapt_python_command("env python3 ~/foo.py") == "env python3 ~/foo.py"
+
+
+class TestAdaptHooks:
+    def test_adapts_hook_commands(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Windows")
+        settings = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [
+                            {
+                                "command": "python3 ~/.claude/scripts/block.py",
+                                "type": "command",
+                            }
+                        ],
+                        "matcher": "Bash",
+                    }
+                ]
+            }
+        }
+        result = _adapt_hooks(settings)
+        hook_cmd = result["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        assert hook_cmd == "py -3 ~/.claude/scripts/block.py"
+
+    def test_adapts_statusline_command(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Windows")
+        settings = {
+            "statusLine": {
+                "command": "python3 ~/.claude/scripts/status.py",
+                "type": "command",
+            }
+        }
+        result = _adapt_hooks(settings)
+        assert result["statusLine"]["command"] == "py -3 ~/.claude/scripts/status.py"
+
+    def test_no_change_on_linux(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Linux")
+        settings = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [
+                            {
+                                "command": "python3 ~/.claude/scripts/block.py",
+                                "type": "command",
+                            }
+                        ],
+                        "matcher": "Bash",
+                    }
+                ]
+            },
+            "statusLine": {
+                "command": "python3 ~/.claude/scripts/status.py",
+                "type": "command",
+            },
+        }
+        result = _adapt_hooks(settings)
+        assert (
+            result["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+            == "python3 ~/.claude/scripts/block.py"
+        )
+        assert result["statusLine"]["command"] == "python3 ~/.claude/scripts/status.py"
+
+    def test_preserves_non_hook_keys(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Windows")
+        settings = {
+            "spinnerTipsEnabled": False,
+            "permissions": {"allow": ["Bash(ls:*)"]},
+        }
+        result = _adapt_hooks(settings)
+        assert result["spinnerTipsEnabled"] is False
+        assert result["permissions"] == {"allow": ["Bash(ls:*)"]}
+
+    def test_does_not_mutate_input(self, monkeypatch):
+        monkeypatch.setattr("scripts.reconcile.platform.system", lambda: "Windows")
+        original_cmd = "python3 ~/.claude/scripts/block.py"
+        settings = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [{"command": original_cmd, "type": "command"}],
+                        "matcher": "",
+                    }
+                ]
+            }
+        }
+        _adapt_hooks(settings)
+        # Original should be unchanged
+        assert settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == original_cmd
 
 
 class TestReconcileClaudeMd:


### PR DESCRIPTION
- Add PYTHON_BOOTSTRAP variable to Makefile (py -3 on Windows, python3 on Unix)
- Add platform adaptation in reconcile.py to transform hook/statusLine commands
- Add tests for _adapt_python_command and _adapt_hooks

Assisted-by: Claude Code (Claude Opus 4.6)
