### PR TITLE
Fix nc/netcat pattern matching CLI flags like -nc

### DIFF
--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -192,7 +192,7 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bcargo\s+publish\b"), "cargo publish"),
     (re.compile(r"\bdotnet\s+nuget\s+push\b"), "dotnet nuget push"),
     # Network/remote access tools
-    (re.compile(r"\b(?:nc|netcat|ncat)\b"), "nc/netcat (network tool)"),
+    (re.compile(r"(?<![-/])\b(?:nc|netcat|ncat)\b"), "nc/netcat (network tool)"),
     (re.compile(rf"{_ENV}{_PATH}scp{_EXE}\b"), "scp"),
     (re.compile(rf"{_ENV}{_PATH}rsync{_EXE}\b"), "rsync"),
     (re.compile(r"\b(?:s?ftp)\b"), "ftp/sftp"),

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -833,6 +833,17 @@ class TestCheckCommand:
     def test_network_tools_blocked(self, command: str, expected: str) -> None:
         assert block_commands.check_command(command) == expected
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "radon cc src/ -a -nc",
+            "some-tool -nc output.txt",
+            "command --nc flag",
+        ],
+    )
+    def test_network_tool_flag_false_positives_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
     # --- Dedicated tools: grep/rg blocked (use built-in Grep tool) ---
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
- Add negative lookbehind for - and / in netcat regex to avoid
  false positives on flags like radon's -nc (no color)
- Add tests for -nc, --nc flag false positives

Assisted-by: Claude Code (Claude Opus 4.6)
