### PR TITLE
Fix find false positive in hyphenated paths, show extra usage on statusline

### DIFF
--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -253,7 +253,7 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "rg (use the built-in Grep tool)",
     ),
     (
-        re.compile(rf"{_ENV}{_PATH}find{_EXE}\b"),
+        re.compile(rf"{_ENV}{_PATH}(?<!-)find{_EXE}\b"),
         "find (use the built-in Glob tool)",
     ),
     # Make targets: block direct python -m invocations that have make equivalents

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -14,6 +14,7 @@ Colors:
 Quota labels show time remaining until reset, e.g.:
   3h4m: 20% | 4d12h: 4%
 At most 2 units of precision: d+h, h+m, m+s, or single unit.
+When 5h quota hits 100% and extra usage is enabled, appends $used/$limit.
 Freshness only shown on stale/error: (!5m)
 
 S/T/P = Session / Today / Project cost (USD).
@@ -120,21 +121,23 @@ def colorize_cost(amount):
     return f"\033[38;5;{_COST_SHADES[idx]}m${amount:.2f}{ANSI_RESET}"
 
 
-def colorize_pct(pct):
-    """Return pct formatted as a string with ANSI color based on magnitude.
+def _pct_color(pct):
+    """Return ANSI color code for a percentage value.
 
     Green  < THRESHOLD_MID
     Yellow THRESHOLD_MID to THRESHOLD_HIGH
     Red    >= THRESHOLD_HIGH
     """
-    value = f"{pct:.0f}%"
     if pct >= THRESHOLD_HIGH * 100:
-        color = ANSI_RED
+        return ANSI_RED
     elif pct >= THRESHOLD_MID * 100:
-        color = ANSI_YELLOW
-    else:
-        color = ANSI_GREEN
-    return f"{color}{value}{ANSI_RESET}"
+        return ANSI_YELLOW
+    return ANSI_GREEN
+
+
+def colorize_pct(pct):
+    """Return pct formatted as a string with ANSI color based on magnitude."""
+    return f"{_pct_color(pct)}{pct:.0f}%{ANSI_RESET}"
 
 
 def format_remaining(resets_at):
@@ -313,7 +316,16 @@ def main():
             label = format_remaining(entry.get("resets_at"))
             if label is None:
                 label = "5h" if bucket == "five_hour" else "1w"
-            parts.append(f"{label}: {colorize_pct(pct)}")
+            segment = f"{label}: {colorize_pct(pct)}"
+            if bucket == "five_hour" and pct >= 100:
+                extra = usage.get("extra_usage")
+                if extra and extra.get("is_enabled"):
+                    used = extra.get("used_credits", 0) / 100
+                    limit = extra.get("monthly_limit", 0) / 100
+                    extra_pct = (used / limit * 100) if limit else 0
+                    color = _pct_color(extra_pct)
+                    segment += f" {color}${used:.0f}/${limit:.0f}{ANSI_RESET}"
+            parts.append(segment)
 
         if stale:
             age_str = format_duration(age_seconds)

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -889,6 +889,17 @@ class TestCheckCommand:
     def test_find_blocked(self, command: str, expected: str) -> None:
         assert block_commands.check_command(command) == expected
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "mkdir -p ~/source/project/skills/plan-find",
+            "ls ~/source/project/plan-find/",
+            "cat path-to-find/file.txt",
+        ],
+    )
+    def test_find_in_path_false_positives_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
     # --- Make targets: block direct python -m for tools with make equivalents ---
 
     @pytest.mark.parametrize(

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -622,6 +622,51 @@ class TestMain:
         assert "Context:" not in output
         assert "Sonnet" in output
 
+    def test_extra_usage_shown_at_100pct(self, monkeypatch, capsys):
+        usage = {
+            "five_hour": {"utilization": 100.0},
+            "seven_day": {"utilization": 22.0},
+            "extra_usage": {
+                "is_enabled": True,
+                "monthly_limit": 5000,
+                "used_credits": 1517,
+                "utilization": 30.34,
+            },
+        }
+        output = self._run_main(monkeypatch, capsys, SAMPLE_STDIN, usage=usage)
+        assert "100%" in output
+        assert "$15/$50" in output
+
+    def test_extra_usage_hidden_below_100pct(self, monkeypatch, capsys):
+        usage = {
+            "five_hour": {"utilization": 80.0},
+            "seven_day": {"utilization": 22.0},
+            "extra_usage": {
+                "is_enabled": True,
+                "monthly_limit": 5000,
+                "used_credits": 1517,
+                "utilization": 30.34,
+            },
+        }
+        output = self._run_main(monkeypatch, capsys, SAMPLE_STDIN, usage=usage)
+        assert "80%" in output
+        assert "$15/$50" not in output
+
+    def test_extra_usage_hidden_when_disabled(self, monkeypatch, capsys):
+        usage = {
+            "five_hour": {"utilization": 100.0},
+            "seven_day": {"utilization": 22.0},
+            "extra_usage": {
+                "is_enabled": False,
+                "monthly_limit": 5000,
+                "used_credits": 0,
+                "utilization": 0,
+            },
+        }
+        output = self._run_main(monkeypatch, capsys, SAMPLE_STDIN, usage=usage)
+        assert "100%" in output
+        assert "$" not in output.split("S/T/P")[0]
+
     def test_default_model(self, monkeypatch, capsys):
         output = self._run_main(monkeypatch, capsys, {})
         assert "Claude" in output


### PR DESCRIPTION
- Add negative lookbehind for - in find pattern to avoid blocking
  commands with find in directory names (e.g. plan-find)
- Show extra usage $spent/$limit on statusline when 5h quota is at 100%
- Color extra usage using same green/yellow/red thresholds as quota %
- Extract _pct_color helper from colorize_pct for reuse

Assisted-by: Claude Code (Claude Opus 4.6)
