### PR TITLE
docs: update screenshot instructions with Linux path and ls-based listing

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -104,9 +104,10 @@
 
 ## Screenshots
 - **Windows**: `~/Pictures/Screenshots/`
-- **Linux**: (TBD)
+- **Linux**: `~/Pictures/Screenshots/`
+- **Start by listing files** — always run `ls -lt ~/Pictures/Screenshots/` first to see available files sorted newest-first. Glob does not reliably sort by date and leads to reading the wrong file
 - **By path**: read the file directly with the Read tool
-- **"Last screenshot"** (or "latest", "most recent", etc.): use Glob to list `~/Pictures/Screenshots/*.png` sorted by modification time, then Read the first result
+- **"Last screenshot"** (or "latest", "most recent", etc.): pick the first file from the `ls -lt` listing above and Read it
 
 ## User Context
 - Linux with Wayland at work, Windows at home


### PR DESCRIPTION
- Set Linux screenshot path to ~/Pictures/Screenshots/ (same as Windows)
- Add guidance to always list files with ls -lt before reading screenshots
- Replace Glob-based approach with ls -lt for reliable date sorting

Assisted-by: Claude Code (Claude Opus 4.6)
