### PR TITLE
fix(hooks): allow --grep flag in git log commands

### DIFF
--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -246,12 +246,13 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\bStop-Service\b", re.IGNORECASE), "Stop-Service"),
     (re.compile(r"\bStop-Process\b", re.IGNORECASE), "Stop-Process"),
     # Dedicated tools: block Bash grep/rg/find — use built-in Grep/Glob tools
+    # Negative lookbehind `(?<!-)` excludes flag-style uses like `git log --grep=`
     (
-        re.compile(rf"{_ENV}{_PATH}grep{_EXE}\b"),
+        re.compile(rf"{_ENV}{_PATH}(?<!-)grep{_EXE}\b"),
         "grep (use the built-in Grep tool)",
     ),
     (
-        re.compile(rf"{_ENV}{_PATH}rg{_EXE}\b"),
+        re.compile(rf"{_ENV}{_PATH}(?<!-)rg{_EXE}\b"),
         "rg (use the built-in Grep tool)",
     ),
     (

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -869,6 +869,10 @@ class TestCheckCommand:
         [
             "echo grepping",
             "cat grep_results.txt",
+            "git log --all --oneline --grep=foo",
+            "git log -i --grep=gitdir --grep=commondir",
+            "git log --grep=pattern",
+            "git log --basic-regexp --grep=foo",
             "ls -lh fetch/org.json",
             "wc -c fetch/org.json",
             "stat fetch/org.json",


### PR DESCRIPTION
Add negative lookbehind to grep/rg block patterns so flag-style uses
like `git log --grep=foo` pass through while bare `grep`/`rg` stay
blocked.

Assisted-by: Claude Code (Claude Opus 4.6)
