### PR TITLE
refactor(statusline)!: delegate usage limit fetching to agentpulse

### DIFF
--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -25,9 +25,7 @@ import json
 import logging
 import logging.handlers
 import sys
-import time
 import urllib.request
-import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -49,11 +47,8 @@ from scripts.config import (  # noqa: E402
     THRESHOLD_MID,
 )
 
-USAGE_CACHE_TTL_SECONDS = 120
-USAGE_CACHE_DIR = DATA_DIR / "statusline-cache"
-USAGE_CACHE_FILE = USAGE_CACHE_DIR / "oauth_usage.json"
-LOG_FILE = USAGE_CACHE_DIR / "statusline.log"
-CREDENTIALS_FILE = Path.home() / ".claude" / ".credentials.json"
+LOG_DIR = DATA_DIR / "statusline-cache"
+LOG_FILE = LOG_DIR / "statusline.log"
 
 logger = logging.getLogger("statusline")
 _log_configured = False
@@ -65,7 +60,7 @@ def _configure_logging():
         return
     _log_configured = True
     try:
-        USAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
         handler = logging.handlers.RotatingFileHandler(
             str(LOG_FILE),
             maxBytes=256 * 1024,
@@ -77,10 +72,6 @@ def _configure_logging():
         logger.setLevel(logging.DEBUG)
     except OSError:
         pass
-
-
-# source: reddit.com/r/ClaudeAI/comments/1rqnryw
-USAGE_API_URL = "https://api.anthropic.com/api/oauth/usage"
 
 
 def format_duration(seconds):
@@ -155,137 +146,55 @@ def format_remaining(resets_at):
         return None
 
 
-def get_oauth_token():
-    try:
-        data = json.loads(CREDENTIALS_FILE.read_text(encoding="utf-8"))
-        return data["claudeAiOauth"]["accessToken"]
-    except (OSError, KeyError, json.JSONDecodeError) as e:
-        logger.error("Failed to read OAuth token: %s", e)
-        return None
-
-
-def fetch_usage():
-    token = get_oauth_token()
-    if not token:
-        logger.warning("No OAuth token available, skipping fetch")
-        return None
-
-    req = urllib.request.Request(USAGE_API_URL)
-    req.add_header("Authorization", f"Bearer {token}")
-    req.add_header("anthropic-beta", "oauth-2025-04-20")
-
-    try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            data = json.loads(resp.read())
-            logger.debug("Fetch succeeded")
-            return data
-    except urllib.error.HTTPError as e:
-        body = ""
-        try:
-            body = e.read().decode()[:200]
-        except Exception:
-            pass
-        logger.error("HTTP %d %s: %s", e.code, e.reason, body)
-        return None
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
-        logger.error("Fetch failed: %s: %s", type(e).__name__, e)
-        return None
-
-
-def _read_cache():
-    """Read and migrate cache file. Returns dict or None."""
-    if not USAGE_CACHE_FILE.exists():
-        return None
-    try:
-        cached = json.loads(USAGE_CACHE_FILE.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    # Migrate old single-letter keys to new schema
-    if "v" in cached and "response_data" not in cached:
-        cached = {
-            "response_data": cached["v"],
-            "last_success_at": cached.get("t", 0),
-            "last_attempt_at": cached.get("t", 0),
-            "consecutive_failures": 0,
-        }
-    return cached
-
-
-def _write_cache(cache_dict):
-    """Write cache dict to disk."""
-    try:
-        USAGE_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        USAGE_CACHE_FILE.write_text(json.dumps(cache_dict), encoding="utf-8")
-    except OSError:
-        pass
-
-
-MAX_COOLDOWN_SECONDS = 3600
-# If no attempt in this window, assume stale failure (sleep/resume) and retry
-STALE_FAILURE_SECONDS = 21600  # 6 hours
+_AGENTPULSE_CONFIG = Path.home() / ".claude" / "agentpulse" / "config.json"
 
 
 def get_usage():
-    """Return (usage_dict, age_seconds, stale) or (None, 0, False)."""
-    now = time.time()
-    cached = _read_cache()
+    """Fetch usage data from agentpulse GET /api/v1/limits.
 
-    if cached:
-        age = now - cached.get("last_success_at", 0)
-        if age < USAGE_CACHE_TTL_SECONDS:
-            return cached.get("response_data"), age, False
-
-        # Stale — check if we should skip fetch due to backoff cooldown
-        failures = cached.get("consecutive_failures", 0)
-        since_last_attempt = now - cached.get("last_attempt_at", 0)
-        # Long gap (sleep/resume) — reset backoff and retry immediately
-        if failures > 0 and since_last_attempt >= STALE_FAILURE_SECONDS:
-            logger.info(
-                "Stale failure: %.0fs since last attempt, resetting backoff",
-                since_last_attempt,
+    Returns (usage_dict, age_seconds, stale) or (None, 0, False).
+    Agentpulse owns OAuth, caching, and backoff — statusline is a pure
+    display client.  The response has buckets (five_hour, seven_day, etc.)
+    and metadata (age_seconds, stale) at the top level; we pass the whole
+    dict as usage_dict so main() can read buckets directly.
+    """
+    try:
+        if not _AGENTPULSE_CONFIG.exists():
+            return None, 0, False
+        cfg = json.loads(_AGENTPULSE_CONFIG.read_text(encoding="utf-8"))
+        host = cfg.get("host", "127.0.0.1")
+        port = cfg.get("port", 17385)
+        url = f"http://{host}:{port}/api/v1/limits"
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            data = json.loads(resp.read())
+            return (
+                data,
+                data.get("age_seconds", 0),
+                data.get("stale", False),
             )
-            failures = 0
-        if failures > 0:
-            cooldown = min(
-                USAGE_CACHE_TTL_SECONDS * (2**failures), MAX_COOLDOWN_SECONDS
-            )
-            if since_last_attempt < cooldown:
-                logger.info(
-                    "Backoff: skipping fetch, %d consecutive failures, "
-                    "cooldown %.0fs, %.0fs remaining",
-                    failures,
-                    cooldown,
-                    cooldown - since_last_attempt,
-                )
-                return cached.get("response_data"), age, True
+    except Exception:
+        return None, 0, False
 
-    result = fetch_usage()
 
-    if result is not None:
-        _write_cache(
-            {
-                "response_data": result,
-                "last_success_at": now,
-                "last_attempt_at": now,
-                "consecutive_failures": 0,
-            }
+def _relay_to_agentpulse(data):
+    """POST statusline data to agentpulse. Silent on failure."""
+    try:
+        if not _AGENTPULSE_CONFIG.exists():
+            return
+        cfg = json.loads(_AGENTPULSE_CONFIG.read_text(encoding="utf-8"))
+        host = cfg.get("host", "127.0.0.1")
+        port = cfg.get("port", 17385)
+        url = f"http://{host}:{port}/statusline/claude"
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(data).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
         )
-        return result, 0, False
-
-    # Fetch failed — update attempt tracking, preserve stale data
-    if cached:
-        cached["last_attempt_at"] = now
-        cached["consecutive_failures"] = cached.get("consecutive_failures", 0) + 1
-        _write_cache(cached)
-        age = now - cached.get("last_success_at", 0)
-        logger.warning(
-            "Fetch failed, consecutive_failures=%d, serving stale cache (%.0fs old)",
-            cached["consecutive_failures"],
-            age,
-        )
-        return cached.get("response_data"), age, True
-
-    return None, 0, False
+        urllib.request.urlopen(req, timeout=1)
+    except Exception:
+        pass
 
 
 def main():
@@ -295,6 +204,8 @@ def main():
     except (json.JSONDecodeError, EOFError):
         print("Claude Code")
         return
+
+    _relay_to_agentpulse(data)
 
     model = data.get("model", {}).get("display_name", "Claude")
     parts = []
@@ -320,8 +231,8 @@ def main():
             if bucket == "five_hour" and pct >= 100:
                 extra = usage.get("extra_usage")
                 if extra and extra.get("is_enabled"):
-                    used = extra.get("used_credits", 0) / 100
-                    limit = extra.get("monthly_limit", 0) / 100
+                    used = extra.get("used_credits_usd", 0)
+                    limit = extra.get("monthly_limit_usd", 0)
                     extra_pct = (used / limit * 100) if limit else 0
                     color = _pct_color(extra_pct)
                     segment += f" {color}${used:.0f}/${limit:.0f}{ANSI_RESET}"

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -9,7 +9,6 @@ config files are ever read.
 import io
 import json
 import re
-import time
 
 import pytest
 
@@ -34,12 +33,10 @@ SAMPLE_STDIN = {
 
 @pytest.fixture(autouse=True)
 def isolate_paths(tmp_path, monkeypatch):
-    """Redirect all module-level paths to tmp_path."""
-    cache_file = tmp_path / "oauth_usage.json"
-    creds_file = tmp_path / "credentials.json"
-    monkeypatch.setattr(statusline, "USAGE_CACHE_FILE", cache_file)
-    monkeypatch.setattr(statusline, "CREDENTIALS_FILE", creds_file)
-    return tmp_path, cache_file, creds_file
+    """Redirect agentpulse config path to tmp_path."""
+    config_file = tmp_path / "agentpulse" / "config.json"
+    monkeypatch.setattr(statusline, "_AGENTPULSE_CONFIG", config_file)
+    return tmp_path, config_file
 
 
 # --- _configure_logging ---
@@ -50,7 +47,7 @@ class TestConfigureLogging:
         # Reset the flag so _configure_logging runs again
         monkeypatch.setattr(statusline, "_log_configured", False)
         monkeypatch.setattr(
-            statusline.USAGE_CACHE_DIR.__class__,
+            statusline.LOG_DIR.__class__,
             "mkdir",
             lambda *a, **kw: (_ for _ in ()).throw(OSError("no perms")),
         )
@@ -132,42 +129,154 @@ class TestFormatRemaining:
         assert result.startswith("4d")
 
 
-# --- get_oauth_token ---
+# --- get_usage (agentpulse) ---
 
 
-class TestGetOauthToken:
-    def test_returns_token(self, isolate_paths):
-        _, _, creds_file = isolate_paths
-        creds_file.write_text(
-            json.dumps({"claudeAiOauth": {"accessToken": "tok_abc"}}),
+class TestGetUsage:
+    def test_no_config_returns_none(self):
+        """No agentpulse config file → no usage data."""
+        usage, age, stale = statusline.get_usage()
+        assert usage is None
+        assert age == 0
+        assert stale is False
+
+    def test_success(self, isolate_paths, monkeypatch):
+        """Agentpulse returns usage data successfully."""
+        tmp_path, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            json.dumps({"host": "127.0.0.1", "port": 17385}),
             encoding="utf-8",
         )
-        assert statusline.get_oauth_token() == "tok_abc"
+        # /api/v1/limits returns buckets + metadata at the top level
+        resp_data = {
+            **SAMPLE_USAGE_RESPONSE,
+            "available": True,
+            "age_seconds": 45,
+            "stale": False,
+        }
+        resp_body = json.dumps(resp_data).encode()
+        mock_resp = io.BytesIO(resp_body)
 
-    def test_missing_file(self):
-        assert statusline.get_oauth_token() is None
+        class FakeContext:
+            def __enter__(self):
+                return mock_resp
 
-    def test_malformed_json(self, isolate_paths):
-        _, _, creds_file = isolate_paths
-        creds_file.write_text("{bad", encoding="utf-8")
-        assert statusline.get_oauth_token() is None
+            def __exit__(self, *a):
+                pass
 
-    def test_missing_key(self, isolate_paths):
-        _, _, creds_file = isolate_paths
-        creds_file.write_text(json.dumps({"other": {}}), encoding="utf-8")
-        assert statusline.get_oauth_token() is None
+        monkeypatch.setattr(
+            statusline.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: FakeContext(),
+        )
+        usage, age, stale = statusline.get_usage()
+        # usage is the full response dict; buckets are at top level
+        assert usage["five_hour"] == SAMPLE_USAGE_RESPONSE["five_hour"]
+        assert usage["seven_day"] == SAMPLE_USAGE_RESPONSE["seven_day"]
+        assert age == 45
+        assert stale is False
 
+    def test_stale_response(self, isolate_paths, monkeypatch):
+        """Agentpulse returns stale cached data."""
+        tmp_path, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            json.dumps({"host": "127.0.0.1", "port": 17385}),
+            encoding="utf-8",
+        )
+        resp_data = {
+            **SAMPLE_USAGE_RESPONSE,
+            "available": True,
+            "age_seconds": 600,
+            "stale": True,
+        }
+        resp_body = json.dumps(resp_data).encode()
+        mock_resp = io.BytesIO(resp_body)
 
-# --- fetch_usage ---
+        class FakeContext:
+            def __enter__(self):
+                return mock_resp
 
+            def __exit__(self, *a):
+                pass
 
-class TestFetchUsage:
-    def test_no_token_returns_none(self, monkeypatch):
-        monkeypatch.setattr(statusline, "get_oauth_token", lambda: None)
-        assert statusline.fetch_usage() is None
+        monkeypatch.setattr(
+            statusline.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: FakeContext(),
+        )
+        usage, age, stale = statusline.get_usage()
+        assert usage["five_hour"] == SAMPLE_USAGE_RESPONSE["five_hour"]
+        assert age == 600
+        assert stale is True
 
-    def test_success(self, monkeypatch):
-        monkeypatch.setattr(statusline, "get_oauth_token", lambda: "tok")
+    def test_network_error_returns_none(self, isolate_paths, monkeypatch):
+        """Agentpulse unreachable → no usage data."""
+        tmp_path, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            json.dumps({"host": "127.0.0.1", "port": 17385}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            statusline.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: (_ for _ in ()).throw(
+                ConnectionRefusedError("refused")
+            ),
+        )
+        usage, age, stale = statusline.get_usage()
+        assert usage is None
+        assert age == 0
+        assert stale is False
+
+    def test_malformed_json_returns_none(self, isolate_paths, monkeypatch):
+        """Agentpulse returns invalid JSON → no usage data."""
+        tmp_path, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            json.dumps({"host": "127.0.0.1", "port": 17385}),
+            encoding="utf-8",
+        )
+        mock_resp = io.BytesIO(b"{bad json")
+
+        class FakeContext:
+            def __enter__(self):
+                return mock_resp
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            statusline.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: FakeContext(),
+        )
+        usage, age, stale = statusline.get_usage()
+        assert usage is None
+        assert age == 0
+        assert stale is False
+
+    def test_corrupt_config_returns_none(self, isolate_paths):
+        """Bad config JSON → no usage data."""
+        _, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text("{bad", encoding="utf-8")
+        usage, age, stale = statusline.get_usage()
+        assert usage is None
+        assert age == 0
+        assert stale is False
+
+    def test_defaults_age_and_stale(self, isolate_paths, monkeypatch):
+        """Response missing age_seconds/stale uses defaults."""
+        tmp_path, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            json.dumps({"host": "127.0.0.1", "port": 17385}),
+            encoding="utf-8",
+        )
+        # Response with buckets but no age_seconds/stale metadata
         resp_body = json.dumps(SAMPLE_USAGE_RESPONSE).encode()
         mock_resp = io.BytesIO(resp_body)
 
@@ -183,381 +292,29 @@ class TestFetchUsage:
             "urlopen",
             lambda req, timeout=None: FakeContext(),
         )
-        result = statusline.fetch_usage()
-        assert result["five_hour"]["utilization"] == 7.0
-
-    def test_network_error(self, monkeypatch):
-        monkeypatch.setattr(statusline, "get_oauth_token", lambda: "tok")
-        monkeypatch.setattr(
-            statusline.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(
-                statusline.urllib.error.URLError("fail")
-            ),
-        )
-        assert statusline.fetch_usage() is None
-
-    def test_http_error_with_body(self, monkeypatch):
-        monkeypatch.setattr(statusline, "get_oauth_token", lambda: "tok")
-
-        err = statusline.urllib.error.HTTPError(
-            url="http://example.com",
-            code=429,
-            msg="Too Many Requests",
-            hdrs=None,
-            fp=io.BytesIO(b"rate limited"),
-        )
-        monkeypatch.setattr(
-            statusline.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(err),
-        )
-        assert statusline.fetch_usage() is None
-
-    def test_http_error_unreadable_body(self, monkeypatch):
-        monkeypatch.setattr(statusline, "get_oauth_token", lambda: "tok")
-
-        err = statusline.urllib.error.HTTPError(
-            url="http://example.com",
-            code=500,
-            msg="Internal Server Error",
-            hdrs=None,
-            fp=None,
-        )
-        # Make read() raise
-        err.read = lambda: (_ for _ in ()).throw(OSError("unreadable"))
-        monkeypatch.setattr(
-            statusline.urllib.request,
-            "urlopen",
-            lambda req, timeout=None: (_ for _ in ()).throw(err),
-        )
-        assert statusline.fetch_usage() is None
-
-
-# --- get_usage ---
-
-
-def _make_cache(
-    response_data,
-    last_success_at,
-    last_attempt_at=None,
-    consecutive_failures=0,
-):
-    """Helper to build a cache dict in the new schema."""
-    return {
-        "response_data": response_data,
-        "last_success_at": last_success_at,
-        "last_attempt_at": last_attempt_at or last_success_at,
-        "consecutive_failures": consecutive_failures,
-    }
-
-
-class TestReadCache:
-    def test_migrates_old_schema(self, isolate_paths):
-        _, cache_file, _ = isolate_paths
-        old_cache = {"v": SAMPLE_USAGE_RESPONSE, "t": 1000.0}
-        cache_file.write_text(json.dumps(old_cache), encoding="utf-8")
-
-        result = statusline._read_cache()
-        assert result["response_data"] == SAMPLE_USAGE_RESPONSE
-        assert result["last_success_at"] == 1000.0
-        assert result["consecutive_failures"] == 0
-
-    def test_reads_new_schema(self, isolate_paths):
-        _, cache_file, _ = isolate_paths
-        new_cache = _make_cache(SAMPLE_USAGE_RESPONSE, 2000.0, consecutive_failures=3)
-        cache_file.write_text(json.dumps(new_cache), encoding="utf-8")
-
-        result = statusline._read_cache()
-        assert result["response_data"] == SAMPLE_USAGE_RESPONSE
-        assert result["consecutive_failures"] == 3
-
-    def test_corrupt_returns_none(self, isolate_paths):
-        _, cache_file, _ = isolate_paths
-        cache_file.write_text("{corrupt", encoding="utf-8")
-        assert statusline._read_cache() is None
-
-    def test_missing_returns_none(self):
-        assert statusline._read_cache() is None
-
-
-class TestGetUsage:
-    def test_fresh_cache_hit(self, isolate_paths, monkeypatch):
-        _, cache_file, _ = isolate_paths
-        cache_time = time.time() - 30
-        cached = _make_cache(SAMPLE_USAGE_RESPONSE, cache_time)
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        fetch_called = []
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: fetch_called.append(1),
-        )
-
         usage, age, stale = statusline.get_usage()
-        assert usage == SAMPLE_USAGE_RESPONSE
-        assert age >= 30
-        assert stale is False
-        assert len(fetch_called) == 0
-
-    def test_fresh_cache_hit_old_schema(self, isolate_paths, monkeypatch):
-        """Old-format cache files still work as fresh cache hits."""
-        _, cache_file, _ = isolate_paths
-        cache_time = time.time() - 30
-        cached = {"v": SAMPLE_USAGE_RESPONSE, "t": cache_time}
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        fetch_called = []
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: fetch_called.append(1),
-        )
-
-        usage, age, stale = statusline.get_usage()
-        assert usage == SAMPLE_USAGE_RESPONSE
-        assert stale is False
-        assert len(fetch_called) == 0
-
-    def test_stale_cache_triggers_fetch(self, isolate_paths, monkeypatch):
-        _, cache_file, _ = isolate_paths
-        stale_time = time.time() - statusline.USAGE_CACHE_TTL_SECONDS - 10
-        cached = _make_cache({"old": True}, stale_time)
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: SAMPLE_USAGE_RESPONSE,
-        )
-
-        usage, age, stale = statusline.get_usage()
-        assert usage == SAMPLE_USAGE_RESPONSE
+        assert usage["five_hour"] == SAMPLE_USAGE_RESPONSE["five_hour"]
         assert age == 0
         assert stale is False
 
-    def test_fetch_failure_uses_stale_cache(self, isolate_paths, monkeypatch):
-        _, cache_file, _ = isolate_paths
-        stale_time = time.time() - statusline.USAGE_CACHE_TTL_SECONDS - 10
-        cached = _make_cache({"stale": True}, stale_time)
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        monkeypatch.setattr(statusline, "fetch_usage", lambda: None)
-
-        usage, age, stale = statusline.get_usage()
-        assert usage == {"stale": True}
-        assert age >= statusline.USAGE_CACHE_TTL_SECONDS
-        assert stale is True
-
-    def test_fetch_failure_increments_consecutive_failures(
-        self, isolate_paths, monkeypatch
-    ):
-        _, cache_file, _ = isolate_paths
-        now = time.time()
-        # last_attempt_at must be past cooldown (120*2^2=480s)
-        cached = _make_cache(
-            {"stale": True},
-            now - 600,
-            last_attempt_at=now - 600,
-            consecutive_failures=2,
+    def test_uses_config_host_port(self, isolate_paths, monkeypatch):
+        """Reads host/port from config file."""
+        tmp_path, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            json.dumps({"host": "10.0.0.1", "port": 9999}),
+            encoding="utf-8",
         )
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
 
-        monkeypatch.setattr(statusline, "fetch_usage", lambda: None)
+        captured_urls = []
+
+        def fake_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            raise ConnectionRefusedError("not real")
+
+        monkeypatch.setattr(statusline.urllib.request, "urlopen", fake_urlopen)
         statusline.get_usage()
-
-        written = json.loads(cache_file.read_text(encoding="utf-8"))
-        assert written["consecutive_failures"] == 3
-
-    def test_success_resets_consecutive_failures(self, isolate_paths, monkeypatch):
-        _, cache_file, _ = isolate_paths
-        now = time.time()
-        # last_attempt_at must be past max cooldown (3600s)
-        cached = _make_cache(
-            {"old": True},
-            now - 5000,
-            last_attempt_at=now - 4000,
-            consecutive_failures=5,
-        )
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: SAMPLE_USAGE_RESPONSE,
-        )
-        statusline.get_usage()
-
-        written = json.loads(cache_file.read_text(encoding="utf-8"))
-        assert written["consecutive_failures"] == 0
-
-    def test_backoff_skips_fetch(self, isolate_paths, monkeypatch):
-        """With recent failures, fetch should be skipped during cooldown."""
-        _, cache_file, _ = isolate_paths
-        now = time.time()
-        # 2 failures: cooldown = 120 * 2^2 = 480s
-        # last_attempt_at was 10s ago, well within cooldown
-        cached = _make_cache(
-            {"stale": True},
-            now - 600,
-            last_attempt_at=now - 10,
-            consecutive_failures=2,
-        )
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        fetch_called = []
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: fetch_called.append(1),
-        )
-
-        usage, age, stale = statusline.get_usage()
-        assert usage == {"stale": True}
-        assert stale is True
-        assert len(fetch_called) == 0
-
-    def test_backoff_allows_fetch_after_cooldown(self, isolate_paths, monkeypatch):
-        """After cooldown expires, fetch should proceed."""
-        _, cache_file, _ = isolate_paths
-        now = time.time()
-        # 1 failure: cooldown = 120 * 2^1 = 240s
-        # last_attempt_at was 300s ago, past cooldown
-        cached = _make_cache(
-            {"stale": True},
-            now - 600,
-            last_attempt_at=now - 300,
-            consecutive_failures=1,
-        )
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: SAMPLE_USAGE_RESPONSE,
-        )
-
-        usage, age, stale = statusline.get_usage()
-        assert usage == SAMPLE_USAGE_RESPONSE
-        assert stale is False
-
-    def test_backoff_caps_at_max_cooldown(self, isolate_paths, monkeypatch):
-        """Cooldown should not exceed MAX_COOLDOWN_SECONDS (3600)."""
-        _, cache_file, _ = isolate_paths
-        now = time.time()
-        # 20 failures: 120 * 2^20 would be huge, but caps at 3600
-        # last_attempt_at was 3601s ago, just past max cooldown
-        cached = _make_cache(
-            {"stale": True},
-            now - 10000,
-            last_attempt_at=now - 3601,
-            consecutive_failures=20,
-        )
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        fetch_called = []
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: fetch_called.append(1) or SAMPLE_USAGE_RESPONSE,
-        )
-
-        usage, age, stale = statusline.get_usage()
-        assert len(fetch_called) == 1
-        assert stale is False
-
-    def test_stale_failure_resets_backoff(self, isolate_paths, monkeypatch):
-        """If last attempt was >6h ago, reset backoff and retry immediately."""
-        _, cache_file, _ = isolate_paths
-        now = time.time()
-        cached = _make_cache(
-            {"stale": True},
-            now - 30000,
-            last_attempt_at=now - 22000,  # >6h ago
-            consecutive_failures=5,
-        )
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        fetch_called = []
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: fetch_called.append(1) or SAMPLE_USAGE_RESPONSE,
-        )
-
-        usage, age, stale = statusline.get_usage()
-        assert len(fetch_called) == 1
-        assert stale is False
-
-    def test_stale_failure_within_window_still_backs_off(
-        self, isolate_paths, monkeypatch
-    ):
-        """If last attempt was <6h ago, normal backoff still applies."""
-        _, cache_file, _ = isolate_paths
-        now = time.time()
-        cached = _make_cache(
-            {"stale": True},
-            now - 10000,
-            last_attempt_at=now - 10,  # 10s ago, well within 6h
-            consecutive_failures=3,
-        )
-        cache_file.write_text(json.dumps(cached), encoding="utf-8")
-
-        fetch_called = []
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: fetch_called.append(1) or SAMPLE_USAGE_RESPONSE,
-        )
-
-        usage, age, stale = statusline.get_usage()
-        assert len(fetch_called) == 0
-        assert stale is True
-
-    def test_no_cache_no_fetch(self, monkeypatch):
-        monkeypatch.setattr(statusline, "fetch_usage", lambda: None)
-        usage, age, stale = statusline.get_usage()
-        assert usage is None
-        assert age == 0
-        assert stale is False
-
-    def test_fetch_writes_cache(self, isolate_paths, monkeypatch):
-        _, cache_file, _ = isolate_paths
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: SAMPLE_USAGE_RESPONSE,
-        )
-
-        statusline.get_usage()
-        assert cache_file.exists()
-        written = json.loads(cache_file.read_text(encoding="utf-8"))
-        assert written["response_data"] == SAMPLE_USAGE_RESPONSE
-        assert written["consecutive_failures"] == 0
-
-    def test_write_cache_oserror_handled(self, isolate_paths, monkeypatch):
-        """_write_cache OSError is silently ignored."""
-        monkeypatch.setattr(
-            statusline.USAGE_CACHE_FILE.parent.__class__,
-            "mkdir",
-            lambda *a, **kw: (_ for _ in ()).throw(OSError("perm denied")),
-        )
-        # Should not raise
-        statusline._write_cache({"response_data": {}, "last_success_at": 0})
-
-    def test_corrupt_cache_ignored(self, isolate_paths, monkeypatch):
-        _, cache_file, _ = isolate_paths
-        cache_file.write_text("{corrupt", encoding="utf-8")
-
-        monkeypatch.setattr(
-            statusline,
-            "fetch_usage",
-            lambda: SAMPLE_USAGE_RESPONSE,
-        )
-        usage, age, stale = statusline.get_usage()
-        assert usage == SAMPLE_USAGE_RESPONSE
-        assert stale is False
+        assert captured_urls == ["http://10.0.0.1:9999/api/v1/limits"]
 
 
 # --- main ---
@@ -689,8 +446,8 @@ class TestMain:
             "seven_day": {"utilization": 22.0},
             "extra_usage": {
                 "is_enabled": True,
-                "monthly_limit": 5000,
-                "used_credits": 1517,
+                "monthly_limit_usd": 50.0,
+                "used_credits_usd": 15.17,
                 "utilization": 30.34,
             },
         }
@@ -704,8 +461,8 @@ class TestMain:
             "seven_day": {"utilization": 22.0},
             "extra_usage": {
                 "is_enabled": True,
-                "monthly_limit": 5000,
-                "used_credits": 1517,
+                "monthly_limit_usd": 50.0,
+                "used_credits_usd": 15.17,
                 "utilization": 30.34,
             },
         }
@@ -719,8 +476,8 @@ class TestMain:
             "seven_day": {"utilization": 22.0},
             "extra_usage": {
                 "is_enabled": False,
-                "monthly_limit": 5000,
-                "used_credits": 0,
+                "monthly_limit_usd": 50.0,
+                "used_credits_usd": 0,
                 "utilization": 0,
             },
         }
@@ -857,8 +614,8 @@ class TestMain:
             "seven_day": {"utilization": 10.0},
             "extra_usage": {
                 "is_enabled": True,
-                "monthly_limit": 0,
-                "used_credits": 0,
+                "monthly_limit_usd": 0,
+                "used_credits_usd": 0,
                 "utilization": 0,
             },
         }


### PR DESCRIPTION
Remove OAuth token reading, direct Anthropic API calls, local JSON
cache with exponential backoff, and all related constants. Statusline
now calls agentpulse GET /api/v1/limits for usage data, making it a
pure display client. Extra usage fields updated from cents
(monthly_limit, used_credits) to dollars (monthly_limit_usd,
used_credits_usd) to match the agentpulse response contract.

BREAKING CHANGE: requires agentpulse running with fetch_limits enabled
Assisted-by: Claude Code (Claude Opus 4.6)
