### PR TITLE
fix(statusline): skip /limits call when fetch_limits is disabled

### DIFF
--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -162,6 +162,8 @@ def get_usage():
         if not _AGENTPULSE_CONFIG.exists():
             return None, 0, False
         cfg = json.loads(_AGENTPULSE_CONFIG.read_text(encoding="utf-8"))
+        if not cfg.get("fetch_limits", True):
+            return None, 0, False
         host = cfg.get("host", "127.0.0.1")
         port = cfg.get("port", 17385)
         url = f"http://{host}:{port}/api/v1/limits"

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -297,6 +297,27 @@ class TestGetUsage:
         assert age == 0
         assert stale is False
 
+    def test_fetch_limits_disabled_skips_request(self, isolate_paths, monkeypatch):
+        """fetch_limits=false in config → skip HTTP call, return None."""
+        _, config_file = isolate_paths
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            json.dumps({"host": "127.0.0.1", "port": 17385, "fetch_limits": False}),
+            encoding="utf-8",
+        )
+        # urlopen should never be called; blow up if it is
+        monkeypatch.setattr(
+            statusline.urllib.request,
+            "urlopen",
+            lambda req, timeout=None: (_ for _ in ()).throw(
+                AssertionError("urlopen called despite fetch_limits=false")
+            ),
+        )
+        usage, age, stale = statusline.get_usage()
+        assert usage is None
+        assert age == 0
+        assert stale is False
+
     def test_uses_config_host_port(self, isolate_paths, monkeypatch):
         """Reads host/port from config file."""
         tmp_path, config_file = isolate_paths


### PR DESCRIPTION
get_usage() now checks the agentpulse config's fetch_limits field and
returns early when it is false, avoiding an unnecessary HTTP request to
the /api/v1/limits endpoint.

Assisted-by: Claude Code (Claude Opus 4.6)
