### PR TITLE
feat(block-commands): block python json.tool, allow jq and bash -n

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -80,6 +80,7 @@
   "permissions": {
     "allow": [
       "Bash(*.claude/venvs/*/python* *.claude/skills/voice/scripts/voice.py*)",
+      "Bash(bash -n *)",
       "Bash(gh api *)",
       "Bash(gh auth status *)",
       "Bash(gh issue list *)",
@@ -549,6 +550,8 @@
       "Bash(gws tasks tasks patch --help)",
       "Bash(gws tasks tasks update --help)",
       "Bash(gws workflow --help)",
+      "Bash(jq . *)",
+      "Bash(jq empty *)",
       "Bash(local-transcribe record *)",
       "Bash(ls *)",
       "Bash(make -p -n)",

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -37,6 +37,7 @@ Blocked categories:
               python, python3, pythonw, perl, ruby, node
   Dedicated tools: grep, rg (use built-in Grep tool), find (use built-in Glob tool)
   Make targets: python -m pytest/mypy/black/flake8/mutmut (use make targets)
+  JSON validation: python -m json.tool (use jq empty / jq .)
   GWS CLI: Gmail, Calendar, Chat (all mutations), Drive, Sheets, Tasks,
            Keep, Forms, Docs, Slides (writes), Classroom, Workflow (all),
            Meet (mutations), Events (subscriptions)
@@ -287,6 +288,12 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(rf"{_ENV}{_PATH}python[3w]?{_EXE}\s+-m\s+mutmut\b"),
         "python -m mutmut (use make mutation-test)",
+    ),
+    # JSON validation: block python's json.tool — use jq instead
+    (
+        re.compile(rf"{_ENV}{_PATH}python[3w]?{_EXE}\s+-m\s+json\.tool\b"),
+        "python -m json.tool "
+        "(use 'jq empty <file>' to validate or 'jq . <file>' to pretty-print)",
     ),
     # GWS CLI mutation blocking (defense-in-depth alongside OAuth scope control)
     # Gmail: NEVER allow mutations — primary email egress risk

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -990,6 +990,55 @@ class TestCheckCommand:
     def test_python_module_non_make_targets_allowed(self, command: str) -> None:
         assert block_commands.check_command(command) is None
 
+    # --- JSON validation: block python -m json.tool, direct users to jq ---
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            (
+                "python -m json.tool",
+                "python -m json.tool "
+                "(use 'jq empty <file>' to validate or 'jq . <file>' to pretty-print)",
+            ),
+            (
+                "python3 -m json.tool settings.json",
+                "python -m json.tool "
+                "(use 'jq empty <file>' to validate or 'jq . <file>' to pretty-print)",
+            ),
+            (
+                "pythonw -m json.tool < data.json",
+                "python -m json.tool "
+                "(use 'jq empty <file>' to validate or 'jq . <file>' to pretty-print)",
+            ),
+            (
+                "/usr/bin/python3 -m json.tool file.json",
+                "python -m json.tool "
+                "(use 'jq empty <file>' to validate or 'jq . <file>' to pretty-print)",
+            ),
+            (
+                "env python3 -m json.tool file.json",
+                "python -m json.tool "
+                "(use 'jq empty <file>' to validate or 'jq . <file>' to pretty-print)",
+            ),
+        ],
+    )
+    def test_python_m_json_tool_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "jq empty file.json",
+            "jq . file.json",
+            "jq '.foo' file.json",
+            "cat file.json | jq .",
+            "python -m json",
+            "python -m jsonlib.tool",
+        ],
+    )
+    def test_json_tool_alternatives_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
     def test_blocked_word_in_heredoc_not_matched(self) -> None:
         cmd = "git commit -m \"$(cat <<'EOF'\ngit add blocked\nEOF\n)\""
         assert block_commands.check_command(cmd) is None


### PR DESCRIPTION
Block python -m json.tool with an error message directing agents to
jq-based alternatives (jq empty for validation, jq . for pretty-print),
avoiding arbitrary-code exposure from python invocations.

Allow narrow jq subcommands and bash -n (syntax check only) in the
permission allowlist so agents can validate JSON and shell scripts
without approval prompts.

Assisted-by: Claude Code (Claude Opus 4.6)
