### PR TITLE
feat(block-commands): block inline execution and package installs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: make install-dev
+        run: make install-dev PY_SYS=python
 
       - name: Generate coverage report
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,5 +18,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: make install-dev PY_SYS=python
+
       - name: Check code formatting
         run: make format-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: make install-dev PY_SYS=python
+
       - name: Run linter
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +20,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: make install-dev PY_SYS=python
 
       - name: Run tests
         run: make test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -18,5 +18,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: make install-dev PY_SYS=python
+
       - name: Run type checker
         run: make typecheck

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,15 @@
 VENV_DIR ?= .venv
 DATA_DIR := $(HOME)/.claude/my-claude-stuff-data
 ifeq ($(OS),Windows_NT)
-    PYTHON := $(VENV_DIR)/Scripts/python.exe
-    PYTHON_BOOTSTRAP := py -3
+    PYTHON ?= $(VENV_DIR)/Scripts/python.exe
 else
-    PYTHON := $(VENV_DIR)/bin/python
-    PYTHON_BOOTSTRAP := python3
+    PYTHON ?= $(VENV_DIR)/bin/python
 endif
+
+# Interpreter used to bootstrap the venv. CI overrides to `python` so the
+# venv is pinned to the matrix Python installed by setup-python instead of
+# the container's system python3 (see ~/source/standards/build/makefile.md).
+PY_SYS ?= python3
 
 $(info venv: $(VENV_DIR))
 
@@ -17,7 +20,7 @@ default: format lint typecheck test coverage  ## Run all checks (format, lint, t
 check: default  ## Alias for default
 
 $(PYTHON):
-	$(PYTHON_BOOTSTRAP) -m venv $(VENV_DIR)
+	$(PY_SYS) -m venv $(VENV_DIR)
 
 install: $(PYTHON)  ## Install package
 	$(PYTHON) -m pip install .

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -6,11 +6,12 @@ Reads JSON from stdin with tool_input.command and checks against blocked
 command patterns. Exits 2 to block, 0 to allow.
 
 Preprocessing pipeline:
-  1. Strip heredoc bodies to avoid false positives from string literals
-  2. Normalize backslashes to forward slashes for consistent path matching
-  3. Check presplit patterns (pipe-to-shell) on full text
-  4. Split command chains (&&, ||, ;, |) respecting quoted strings
-  5. Check each segment against BLOCKED_PATTERNS
+  1. Check heredoc-to-runtime on raw text (before heredoc stripping)
+  2. Strip heredoc bodies to avoid false positives from string literals
+  3. Normalize backslashes to forward slashes for consistent path matching
+  4. Check presplit patterns (pipe-to-shell) on full text
+  5. Split command chains (&&, ||, ;, |) respecting quoted strings
+  6. Check each segment against BLOCKED_PATTERNS
 
 Blocked categories:
   Git: -C flag (blocked for absolute/parent/home paths;
@@ -38,6 +39,13 @@ Blocked categories:
   Dedicated tools: grep, rg (use built-in Grep tool), find (use built-in Glob tool)
   Make targets: python -m pytest/mypy/black/flake8/mutmut (use make targets)
   JSON validation: python -m json.tool (use jq empty / jq .)
+  Inline execution: python -c, node -e, ruby/perl -e, php -r,
+       pipe-to-runtime (any ``| <runtime>``),
+       heredoc-to-runtime (``<runtime> <<EOF``),
+       process substitution (``<runtime> <(...)``),
+       shell -c wrapping a runtime (``bash -c "python ..."``),
+       arbitrary ``python <path>.py`` outside ``scripts/`` directories
+  Package install: pip install, npm install, cargo install, go install
   Semgrep: --autofix/-a/--replacement (mutation), login/logout/publish/
            install-semgrep-pro (state or network egress)
   GWS CLI: Gmail, Calendar, Chat (all mutations), Drive, Sheets, Tasks,
@@ -72,21 +80,37 @@ _FLAGS = r"(?:\s+(?:-\S+|\S+=\S+)(?:\s+\S+)?)*"
 # Optional Windows-style single-letter flags: /q, /f, /S, etc.
 _WFLAGS = r"(?:\s+/[a-zA-Z])*"
 
-# Shells and interpreters that should never receive piped remote content.
-# Covers common defaults: POSIX shells, popular interactive shells,
-# and scripting language interpreters.  Windows .exe variants are
-# handled by the optional _EXE suffix already defined above.
+# Shells and interpreters that should never receive piped remote content
+# or execute inline/stdin scripts supplied by the agent.  Covers POSIX
+# shells, popular interactive shells, and scripting language interpreters.
+# Windows .exe variants are handled by the optional _EXE suffix.
 _PIPE_SHELLS = (
     r"(?:ba|da|k|c|tc|z|fi)?sh"  # sh, bash, dash, ksh, csh, tcsh, zsh, fish
     r"|python[3w]?"  # python, python3, pythonw
-    r"|perl|ruby|node"
+    r"|perl|ruby|node|php"
 )
 
-# Patterns checked BEFORE chain splitting (span pipes intentionally)
+# Patterns checked on raw command BEFORE heredoc stripping — needed so
+# `python <<EOF ... EOF` can be detected (heredoc stripping drops the
+# language marker by splitting on `<<`).
+HEREDOC_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(rf"{_PATH}(?:{_PIPE_SHELLS}){_EXE}\s*<<-?\s*['\"]?\w+"),
+        "heredoc to runtime (inline execution — file a missing test instead)",
+    ),
+]
+
+# Patterns checked AFTER heredoc stripping but BEFORE chain splitting
+# (they span pipes intentionally).  Ordered so the curl/wget case keeps
+# its historical "pipe-to-shell" message for existing consumers.
 PRESPLIT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(rf"(?:curl|wget)\b.*\|\s*{_PATH}(?:{_PIPE_SHELLS}){_EXE}\b"),
         "pipe-to-shell",
+    ),
+    (
+        re.compile(rf"\|\s*{_PATH}(?:{_PIPE_SHELLS}){_EXE}\b"),
+        "pipe to runtime (inline execution — file a missing test instead)",
     ),
 ]
 
@@ -296,6 +320,75 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         re.compile(rf"{_ENV}{_PATH}python[3w]?{_EXE}\s+-m\s+json\.tool\b"),
         "python -m json.tool "
         "(use 'jq empty <file>' to validate or 'jq . <file>' to pretty-print)",
+    ),
+    # Shell -c wrapping a runtime: bash -c "python ...", sh -c 'node ...'
+    # Must come BEFORE individual inline-execution patterns so the outer
+    # wrapper is identified rather than the inner `-c`/`-e`.
+    # Plain shell -c with non-runtime commands (git, CI scripts) is allowed.
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}(?:ba|da|k|c|tc|z|fi)?sh{_EXE}\s+-c\s+"
+            r"['\"]?\s*"
+            rf"{_PATH}(?:python[3w]?|node|perl|ruby|php)\b"
+        ),
+        "shell -c wrapping runtime (inline execution — "
+        "use Read/Glob/Grep or file a missing test)",
+    ),
+    # Inline code execution (python -c / -m...-c, node -e, ruby/perl -e, php -r)
+    # Use Read/Glob/Grep to inspect files; file missing tests for runtime checks.
+    (
+        re.compile(rf"{_ENV}{_PATH}python[3w]?{_EXE}\b[^|;&]*\s-c\b"),
+        "python -c (inline execution — use Read/Glob/Grep or file a missing test)",
+    ),
+    (
+        re.compile(rf"{_ENV}{_PATH}node{_EXE}\b[^|;&]*\s(?:-e|--eval)\b"),
+        "node -e/--eval (inline execution — "
+        "use Read/Glob/Grep or file a missing test)",
+    ),
+    (
+        re.compile(rf"{_ENV}{_PATH}(?:ruby|perl){_EXE}\b[^|;&]*\s-e\b"),
+        "ruby/perl -e (inline execution — use Read/Glob/Grep "
+        "or file a missing test)",
+    ),
+    (
+        re.compile(rf"{_ENV}{_PATH}php{_EXE}\b[^|;&]*\s-r\b"),
+        "php -r (inline execution — use Read/Glob/Grep or file a missing test)",
+    ),
+    # Process substitution to runtime: python <(...), bash <(...), etc.
+    (
+        re.compile(rf"{_ENV}{_PATH}(?:{_PIPE_SHELLS}){_EXE}\s+<\("),
+        "process substitution to runtime (inline execution — "
+        "use Read/Glob/Grep or file a missing test)",
+    ),
+    # Running arbitrary .py files — usually agent-authored "explore" scripts.
+    # Allowed when the path contains 'scripts/' (review skill scripts live
+    # under ~/.claude/skills/review/scripts/ and project code under scripts/).
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}python[3w]?{_EXE}\s+"
+            r"(?!-)"
+            r"(?!.*scripts/)"
+            r"\S+\.py\b"
+        ),
+        "running arbitrary .py file (use Read/Glob/Grep; "
+        "file a missing test if runtime verification is required)",
+    ),
+    # Package installation against the user's environment
+    (
+        re.compile(r"\bpip[23]?\s+install\b"),
+        "pip install (report missing dep as a finding, do not install)",
+    ),
+    (
+        re.compile(r"\bnpm\s+install\b"),
+        "npm install (report missing dep as a finding, do not install)",
+    ),
+    (
+        re.compile(r"\bcargo\s+install\b"),
+        "cargo install (report missing dep as a finding, do not install)",
+    ),
+    (
+        re.compile(r"\bgo\s+install\b"),
+        "go install (report missing dep as a finding, do not install)",
     ),
     # Semgrep autofix: block --autofix/-a/--replacement (mutate source files)
     (
@@ -643,23 +736,32 @@ def check_command(command: str) -> str | None:
     """Return the blocked command name if matched, or None if allowed.
 
     Pipeline:
-      1. Strip heredoc body to avoid false positives from string literals
-      2. Normalize backslashes to forward slashes for consistent path matching
-      3. Check presplit patterns on full text (pipe-to-shell detection)
-      4. Split command chains respecting quoted strings
-      5. Check each segment against BLOCKED_PATTERNS
+      1. Check heredoc-to-runtime on raw text (before stripping — the
+         language marker sits before `<<` and would otherwise survive,
+         but the ``<<`` itself is needed to recognise the heredoc form)
+      2. Strip heredoc body to avoid false positives from string literals
+      3. Normalize backslashes to forward slashes for consistent path matching
+      4. Check presplit patterns on full text (pipe-to-shell detection)
+      5. Split command chains respecting quoted strings
+      6. Check each segment against BLOCKED_PATTERNS
     """
-    # 1. Strip heredoc body
+    # 1. Heredoc-to-runtime check on raw command (before heredoc stripping)
+    raw_normalized = command.replace("\\", "/")
+    for pattern, name in HEREDOC_PATTERNS:
+        if pattern.search(raw_normalized):
+            return name
+
+    # 2. Strip heredoc body
     check_text = command.split("<<")[0] if "<<" in command else command
-    # 2. Normalize backslashes to forward slashes
+    # 3. Normalize backslashes to forward slashes
     check_text = check_text.replace("\\", "/")
 
-    # 3. Check presplit patterns (span pipes intentionally)
+    # 4. Check presplit patterns (span pipes intentionally)
     for pattern, name in PRESPLIT_PATTERNS:
         if pattern.search(check_text):
             return name
 
-    # 3b. GraphQL query exception: gh api graphql with -f/-F flags is only
+    # 4b. GraphQL query exception: gh api graphql with -f/-F flags is only
     # mutating if the query contains a 'mutation' operation.  Query operations
     # (explicit 'query' keyword or shorthand '{...}') are read-only.
     if _GH_API_GRAPHQL_RE.search(check_text):
@@ -667,10 +769,10 @@ def check_command(command: str) -> str | None:
             return "gh api (mutation)"
         return None
 
-    # 4. Split into chain segments
+    # 5. Split into chain segments
     segments = split_command_chain(check_text)
 
-    # 5. Check each segment against blocked patterns
+    # 6. Check each segment against blocked patterns
     for segment in segments:
         for pattern, name in BLOCKED_PATTERNS:
             if pattern.search(segment):

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -89,7 +89,7 @@ class TestCheckCommand:
             "ls -la",
             "make test",
             "make format",
-            "python3 script.py",
+            "python3 scripts/foo.py",
             "echo hello",
             "",
         ],
@@ -746,7 +746,6 @@ class TestCheckCommand:
     @pytest.mark.parametrize(
         "command",
         [
-            "npm install",
             "npm test",
             "gem install bundler",
             "cargo build",
@@ -896,7 +895,6 @@ class TestCheckCommand:
             "wc -c fetch/org.json",
             "stat fetch/org.json",
             "du -h fetch/org.json",
-            "python3 -c 'from pathlib import Path; p=Path(\"fetch/org.json\")'",
             "cat target/output.txt",
             "ls merge-results/",
             "wc -l large_file.txt",
@@ -976,11 +974,9 @@ class TestCheckCommand:
     @pytest.mark.parametrize(
         "command",
         [
-            "python -m pip install foo",
             "python3 -m venv .venv",
             "python -m http.server 8080",
-            "python3 script.py",
-            "python -c 'print(1)'",
+            "python3 scripts/foo.py",
             "make test",
             "make typecheck",
             "make format",
@@ -1120,6 +1116,259 @@ class TestCheckCommand:
         assert block_commands.check_command(cmd) == "git push"
 
 
+class TestInlineExecutionBlocks:
+    """Block inline code execution for language runtimes."""
+
+    _PY_C = (
+        "python -c (inline execution — use Read/Glob/Grep " "or file a missing test)"
+    )
+    _NODE_E = (
+        "node -e/--eval (inline execution — "
+        "use Read/Glob/Grep or file a missing test)"
+    )
+    _RUBY_E = (
+        "ruby/perl -e (inline execution — use Read/Glob/Grep " "or file a missing test)"
+    )
+    _PHP_R = "php -r (inline execution — use Read/Glob/Grep " "or file a missing test)"
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("python -c 'print(1)'", _PY_C),
+            ('python -c "print(1)"', _PY_C),
+            ("python3 -c 'print(1)'", _PY_C),
+            ("pythonw -c 'x'", _PY_C),
+            ("/usr/bin/python3 -c 'x'", _PY_C),
+            ("env python3 -c 'x'", _PY_C),
+            # Even when routed through -m, -c still executes inline code
+            ("python -m mymodule -c 'print(1)'", _PY_C),
+            ("node -e 'console.log(1)'", _NODE_E),
+            ('node -e "console.log(1)"', _NODE_E),
+            ("/usr/bin/node -e 'x'", _NODE_E),
+            ("node --eval 'console.log(1)'", _NODE_E),
+            ('node --eval="console.log(1)"', _NODE_E),
+            ("ruby -e 'puts 1'", _RUBY_E),
+            ("perl -e 'print 1'", _RUBY_E),
+            ("/usr/bin/ruby -e 'x'", _RUBY_E),
+            ("php -r 'echo 1;'", _PHP_R),
+            ('php -r "echo 1;"', _PHP_R),
+        ],
+    )
+    def test_inline_execution_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Legit flags that are not inline execution
+            "python -m venv .venv",
+            "python -m http.server 8080",
+            "node --version",
+            "node server.js",
+            "ruby --version",
+            "perl --version",
+            "php --version",
+            # node -c is a syntax check (read-only) and not in our block list
+            "node -c file.js",
+        ],
+    )
+    def test_inline_execution_false_positives_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+    # --- Heredoc to runtime ---
+
+    _HEREDOC = "heredoc to runtime (inline execution — file a missing test instead)"
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("python <<EOF\nprint(1)\nEOF", _HEREDOC),
+            ("python3 <<EOF\nprint(1)\nEOF", _HEREDOC),
+            ("python <<'EOF'\nprint(1)\nEOF", _HEREDOC),
+            ('python <<"EOF"\nprint(1)\nEOF', _HEREDOC),
+            ("bash <<EOF\necho hi\nEOF", _HEREDOC),
+            ("sh <<-EOF\n  echo hi\nEOF", _HEREDOC),
+            ("node <<EOF\nconsole.log(1)\nEOF", _HEREDOC),
+            ("ruby <<EOF\nputs 1\nEOF", _HEREDOC),
+            ("perl <<EOF\nprint 1\nEOF", _HEREDOC),
+            ("php <<EOF\necho 1;\nEOF", _HEREDOC),
+            ("/usr/bin/python3 <<EOF\nprint(1)\nEOF", _HEREDOC),
+        ],
+    )
+    def test_heredoc_to_runtime_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Heredoc into a non-runtime: still allowed
+            "cat <<EOF\nhello\nEOF",
+            "tee file.txt <<EOF\nhello\nEOF",
+            # git commit body heredoc (no runtime after <<)
+            "git commit -m \"$(cat <<'EOF'\nmsg body\nEOF\n)\"",
+        ],
+    )
+    def test_heredoc_to_non_runtime_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+    # --- Process substitution to runtime ---
+
+    _PROCSUB = (
+        "process substitution to runtime (inline execution — "
+        "use Read/Glob/Grep or file a missing test)"
+    )
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("python <(echo 'print(1)')", _PROCSUB),
+            ("python3 <(cat foo.py)", _PROCSUB),
+            ("bash <(echo 'ls')", _PROCSUB),
+            ("sh <(echo 'ls')", _PROCSUB),
+            ("node <(cat foo.js)", _PROCSUB),
+            ("ruby <(echo 'puts 1')", _PROCSUB),
+        ],
+    )
+    def test_process_substitution_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    # --- Shell -c wrapping a runtime ---
+
+    _SHELL_WRAP = (
+        "shell -c wrapping runtime (inline execution — "
+        "use Read/Glob/Grep or file a missing test)"
+    )
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("bash -c \"python -c 'print(1)'\"", _SHELL_WRAP),
+            ("bash -c 'python script.py'", _SHELL_WRAP),
+            ('sh -c "python3 -c x"', _SHELL_WRAP),
+            ("sh -c 'node -e x'", _SHELL_WRAP),
+            ("zsh -c 'perl -e x'", _SHELL_WRAP),
+            ("bash -c 'ruby -e x'", _SHELL_WRAP),
+            ("bash -c 'php -r x'", _SHELL_WRAP),
+            ('/bin/bash -c "python foo.py"', _SHELL_WRAP),
+        ],
+    )
+    def test_shell_wrap_runtime_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Plain bash -c with a non-runtime command — legit CI/git pattern
+            "bash -c 'git status'",
+            'bash -c "git log --oneline"',
+            "sh -c 'make test'",
+            "bash -c 'echo hello'",
+            "bash -c 'ls -la'",
+        ],
+    )
+    def test_shell_wrap_non_runtime_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+    # --- Arbitrary .py file execution ---
+
+    _ARBITRARY_PY = (
+        "running arbitrary .py file (use Read/Glob/Grep; "
+        "file a missing test if runtime verification is required)"
+    )
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("python script.py", _ARBITRARY_PY),
+            ("python3 explore.py", _ARBITRARY_PY),
+            ("pythonw tool.py", _ARBITRARY_PY),
+            ("python /tmp/explore.py", _ARBITRARY_PY),
+            ("python ./explore.py", _ARBITRARY_PY),
+            ("/usr/bin/python3 foo.py", _ARBITRARY_PY),
+            ("env python3 explore.py", _ARBITRARY_PY),
+        ],
+    )
+    def test_arbitrary_py_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Project scripts and review-skill scripts live under scripts/
+            "python scripts/foo.py",
+            "python3 scripts/block_commands.py",
+            "python ./scripts/helper.py",
+            "python ~/.claude/skills/review/scripts/validate-findings.py file.md",
+            "python ~/.claude/skills/review/scripts/render-review.py",
+            "python /home/user/src/proj/scripts/explore.py",
+        ],
+    )
+    def test_scripts_path_py_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
+class TestPackageInstallBlocks:
+    """Block package installation against the user's environment."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            (
+                "pip install foo",
+                "pip install (report missing dep as a finding, do not install)",
+            ),
+            (
+                "pip3 install foo bar",
+                "pip install (report missing dep as a finding, do not install)",
+            ),
+            (
+                "python -m pip install foo",
+                "pip install (report missing dep as a finding, do not install)",
+            ),
+            (
+                "python3 -m pip install --upgrade foo",
+                "pip install (report missing dep as a finding, do not install)",
+            ),
+            (
+                "npm install",
+                "npm install (report missing dep as a finding, do not install)",
+            ),
+            (
+                "npm install --save-dev foo",
+                "npm install (report missing dep as a finding, do not install)",
+            ),
+            (
+                "cargo install ripgrep",
+                "cargo install (report missing dep as a finding, do not install)",
+            ),
+            (
+                "go install example.com/cmd/foo@latest",
+                "go install (report missing dep as a finding, do not install)",
+            ),
+        ],
+    )
+    def test_package_install_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Not install subcommands
+            "pip list",
+            "pip show foo",
+            "npm ls",
+            "npm test",
+            "npm run build",
+            "cargo build",
+            "cargo test",
+            "go build",
+            "go test ./...",
+        ],
+    )
+    def test_package_non_install_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
 class TestCommandChainSplitting:
     """Test chain splitting and per-segment checking."""
 
@@ -1214,6 +1463,27 @@ class TestPresplitPatterns:
         ],
     )
     def test_pipe_to_shell_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    _GENERIC_PIPE = "pipe to runtime (inline execution — file a missing test instead)"
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            # Non-curl/wget source piped to a runtime — catches agent-authored
+            # stdin-script patterns (cat script | python).
+            ("cat foo.py | python", _GENERIC_PIPE),
+            ("cat foo.py | python3", _GENERIC_PIPE),
+            ("echo 'print(1)' | python", _GENERIC_PIPE),
+            ("cat foo.js | node", _GENERIC_PIPE),
+            ("cat foo.rb | ruby", _GENERIC_PIPE),
+            ("cat foo.pl | perl", _GENERIC_PIPE),
+            ("cat foo.sh | bash", _GENERIC_PIPE),
+            ("echo 'ls' | sh", _GENERIC_PIPE),
+            ("cat foo.php | php", _GENERIC_PIPE),
+        ],
+    )
+    def test_generic_pipe_to_runtime_blocked(self, command: str, expected: str) -> None:
         assert block_commands.check_command(command) == expected
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
- Block inline code execution: python -c, node -e/--eval, ruby/perl -e,
  php -r, shell -c wrapping a runtime, heredoc to runtime, process
  substitution to runtime, and general pipe-to-runtime beyond curl/wget
- Block arbitrary python <path>.py outside scripts/ directories
- Block pip/npm/cargo/go install
- Align Makefile and workflows with ~/source/standards/build/makefile.md:
  introduce PY_SYS variable so CI pins the venv to setup-python's matrix
  Python (PY_SYS=python) instead of the container's default python3,
  fixing act matrix legs targeting Python >= 3.12

Assisted-by: Claude Code (Claude Opus 4.7)
