### PR TITLE
feat(block-commands): block make -C for absolute, parent, home, pwd subs

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -5,6 +5,7 @@
 ## Restrictions
 - **Never execute**: `git push`, `sudo`, or `su`
 - **`git -C` is allowed for relative subdirectory paths** (e.g., `git -C nexus-ui remote -v`), **`git-worktrees/` paths** (e.g., `git -C git-worktrees/my-pr/ log`), **and read-only subcommands** (`status`, `log`, `diff`) with any path — blocked for absolute (`/`), parent (`..`), and home (`~`) paths
+- **`make -C` / `make --directory=` is allowed for relative subdirectory paths** (e.g., `make -C nexus-ui test`) — blocked for absolute (`/`), parent (`..`), home (`~`) paths and `pwd` substitutions (`$(pwd)`, `` `pwd` ``, `$PWD`, `${PWD}`); omit `-C` if you mean cwd
 - **No commits to default branches** unless explicitly instructed
 - **Work on fork/feature branches** or current branch if specified
 - **Never use destructive data operations** (wipe DB, drop tables, destructive migrations) without explicit user approval

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -22,7 +22,10 @@ Blocked categories:
        stash (except list/show), commit --amend/-a, checkout -- (discard),
        restore (except --staged), rebase, filter-branch, filter-repo,
        reflog expire, gc --prune=now
-  Unix: sudo, su, rm -r, make reconcile, find -delete, chmod 777, mkfs,
+  Make: -C/--directory flag (blocked for absolute/parent/home paths and
+        pwd substitutions like $(pwd), `pwd`, $PWD; subdirectory paths allowed),
+        reconcile
+  Unix: sudo, su, rm -r, find -delete, chmod 777, mkfs,
         dd of=/dev/, shred, truncate
   Windows: rd/rmdir /s, del/erase /s, format, diskpart, bcdedit, sc delete,
            cipher /w, Remove-Item -Recurse, reg delete, takeown,
@@ -194,6 +197,17 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "rm (recursive)",
     ),
     (re.compile(rf"{_ENV}{_PATH}make{_EXE}{_FLAGS}\s+reconcile\b"), "make reconcile"),
+    # make -C / --directory: block absolute, parent (..), home (~) paths,
+    # and pwd substitutions ($(pwd), `pwd`, $PWD, ${PWD}).
+    # Relative subdirectory paths are allowed (e.g. make -C nexus-ui test).
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}make{_EXE}\s+(?:-C\s+|--directory=)"
+            r"(?:\.\.|[/~]|\$\(pwd\)|`pwd`|\$\{?PWD\}?)"
+        ),
+        "make -C/--directory (blocked for absolute/parent/home paths and pwd"
+        " substitutions — omit -C if you mean cwd; subdirectory paths are allowed)",
+    ),
     (
         re.compile(
             rf"{_ENV}{_PATH}git{_EXE}{_FLAGS}\s+commit\s.*"

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -248,6 +248,44 @@ class TestCheckCommand:
     ) -> None:
         assert block_commands.check_command(command) == expected
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "make -C /some/path test",
+            "make -C /tmp build",
+            "make --directory=/path test",
+            "make -C ../sibling test",
+            "make -C .. lint",
+            "make -C ~/repo test",
+            "make -C ~/repos/other build",
+            "make -C $(pwd) test",
+            "make -C ${PWD} test",
+            "make -C $PWD test",
+            "make -C `pwd` test",
+            "make --directory=$(pwd) test",
+            "make --directory=`pwd` test",
+            "/usr/bin/make -C /tmp test",
+            "env make -C $(pwd) build",
+        ],
+    )
+    def test_make_dash_c_blocked(self, command: str) -> None:
+        assert block_commands.check_command(command) is not None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "make -C nexus-ui test",
+            "make -C ./subdir test",
+            "make -C subdir build",
+            "make -C nexus-ui lint",
+            "make --directory=subdir test",
+            "make --directory=./subdir build",
+            "make -C .hidden-dir test",
+        ],
+    )
+    def test_make_dash_c_relative_subdir_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
     def test_git_commit_without_append_a_allowed(self) -> None:
         assert block_commands.check_command("git commit -m test") is None
         assert block_commands.check_command("git commit -m fix-a-bug") is None


### PR DESCRIPTION
Mirror the git -C rule for make. Block make -C / make --directory= when
the path is absolute (/), parent (..), home (~), or a pwd substitution
($(pwd), `pwd`, $PWD, ${PWD}). Relative subdirectory paths still pass
through. Pattern is placed after the make reconcile rule so existing
"make reconcile" block messages stay intact.

Why: agents kept invoking `make -C $(pwd) <target>` which produces
permission prompts because the allowlist entries are scoped to plain
`make <target>`. A hard block with an explanatory message stops the
behavior at its source.

Assisted-by: Claude Code (Claude Opus 4.7 1M context)
