### PR TITLE
fix(block-commands): anchor scripts/ and .claude/ exceptions to directory boundaries

### DIFF
--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -375,13 +375,14 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "use Read/Glob/Grep or file a missing test)",
     ),
     # Running arbitrary .py files — usually agent-authored "explore" scripts.
-    # Allowed when the path contains 'scripts/' (review skill scripts live
-    # under ~/.claude/skills/review/scripts/ and project code under scripts/).
+    # Allowed when the path contains 'scripts/' or '.claude/' (skill and
+    # hook scripts live under .claude/ and project code under scripts/).
     (
         re.compile(
             rf"{_ENV}{_PATH}python[3w]?{_EXE}\s+"
             r"(?!-)"
-            r"(?!.*scripts/)"
+            r"(?!(?:scripts/|\S*[/~]scripts/))"
+            r"(?!(?:\.claude/|\S*[/~]\.claude/))"
             r"\S+\.py\b"
         ),
         "running arbitrary .py file (use Read/Glob/Grep; "

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -1324,6 +1324,12 @@ class TestInlineExecutionBlocks:
             ("python ./explore.py", _ARBITRARY_PY),
             ("/usr/bin/python3 foo.py", _ARBITRARY_PY),
             ("env python3 explore.py", _ARBITRARY_PY),
+            # Paths that look like .claude/ but aren't
+            ("python3 /stupid.claude/evil.py", _ARBITRARY_PY),
+            ("python3 foo.claude/bar.py", _ARBITRARY_PY),
+            # Paths that look like scripts/ but aren't
+            ("python3 myfavscripts/evil.py", _ARBITRARY_PY),
+            ("python3 /tmp/notscripts/foo.py", _ARBITRARY_PY),
         ],
     )
     def test_arbitrary_py_blocked(self, command: str, expected: str) -> None:
@@ -1339,6 +1345,10 @@ class TestInlineExecutionBlocks:
             "python ~/.claude/skills/review/scripts/validate-findings.py file.md",
             "python ~/.claude/skills/review/scripts/render-review.py",
             "python /home/user/src/proj/scripts/explore.py",
+            # Skill and hook scripts under .claude/ directories
+            "python3 .claude/skills/gate-assessment/consolidate.py --input-dir foo",
+            "python .claude/hooks/my-hook.py",
+            "python3 /home/user/.claude/skills/review/analyze.py file.md",
         ],
     )
     def test_scripts_path_py_allowed(self, command: str) -> None:


### PR DESCRIPTION
- Add .claude/ as allowed path for arbitrary .py execution (skill/hook scripts)
- Anchor both scripts/ and .claude/ lookaheads to require path separator or
  start-of-path, preventing substring matches like myfavscripts/ or foo.claude/

Assisted-by: Claude Code (Claude Opus 4.6)
