### PR TITLE
fix(block-commands): allow grep/rg as downstream pipe filters

### DIFF
--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -10,8 +10,11 @@ Preprocessing pipeline:
   2. Strip heredoc bodies to avoid false positives from string literals
   3. Normalize backslashes to forward slashes for consistent path matching
   4. Check presplit patterns (pipe-to-shell) on full text
-  5. Split command chains (&&, ||, ;, |) respecting quoted strings
-  6. Check each segment against BLOCKED_PATTERNS
+  5. Split command chains (&&, ||, ;, |) respecting quoted strings.
+     Each segment is tagged with whether it followed a `|` (pipe filter).
+  6. Check each segment against BLOCKED_PATTERNS, plus LEADING_ONLY_PATTERNS
+     for non-filter segments only (so e.g. `cmd | grep foo` is allowed but
+     bare `grep foo` and `cmd && grep foo` remain blocked)
 
 Blocked categories:
   Git: -C flag (blocked for absolute/parent/home paths;
@@ -39,7 +42,9 @@ Blocked categories:
   Cross-platform: curl/wget piped to shell/interpreter (presplit)
               sh, bash, dash, ksh, csh, tcsh, zsh, fish,
               python, python3, pythonw, perl, ruby, node
-  Dedicated tools: grep, rg (use built-in Grep tool), find (use built-in Glob tool)
+  Dedicated tools: grep, rg (use built-in Grep tool when searching the
+                   filesystem; allowed as downstream pipe filters, e.g.
+                   `cmd --help | grep foo`), find (use built-in Glob tool)
   Make targets: python -m pytest/mypy/black/flake8/mutmut (use make targets)
   JSON validation: python -m json.tool (use jq empty / jq .)
   Inline execution: python -c, node -e, ruby/perl -e, php -r,
@@ -294,16 +299,10 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # PowerShell process/service cmdlets
     (re.compile(r"\bStop-Service\b", re.IGNORECASE), "Stop-Service"),
     (re.compile(r"\bStop-Process\b", re.IGNORECASE), "Stop-Process"),
-    # Dedicated tools: block Bash grep/rg/find — use built-in Grep/Glob tools
-    # Negative lookbehind `(?<!-)` excludes flag-style uses like `git log --grep=`
-    (
-        re.compile(rf"{_ENV}{_PATH}(?<!-)grep{_EXE}\b"),
-        "grep (use the built-in Grep tool)",
-    ),
-    (
-        re.compile(rf"{_ENV}{_PATH}(?<!-)rg{_EXE}\b"),
-        "rg (use the built-in Grep tool)",
-    ),
+    # Dedicated tools: block Bash find — use built-in Glob tool.
+    # grep/rg are in LEADING_ONLY_PATTERNS because they are still useful as
+    # downstream filters on another command's stdout (the built-in Grep tool
+    # only searches files, not piped input).
     (
         re.compile(rf"^{_ENV}{_PATH}(?<!-)find{_EXE}\b"),
         "find (use the built-in Glob tool)",
@@ -681,17 +680,41 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     ),
 ]
 
+# Patterns that block only the LEADING command of a chain segment.  Skipped
+# when the segment is a downstream pipe filter (the segment after a `|`),
+# since those tools are still legitimate as filters on another command's
+# stdout — the built-in Grep tool can't operate on piped input.
+# Negative lookbehind `(?<!-)` excludes flag-style uses like `git log --grep=`.
+LEADING_ONLY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(rf"{_ENV}{_PATH}(?<!-)grep{_EXE}\b"),
+        "grep (use the built-in Grep tool, or pipe another command's output"
+        " through grep — `cmd | grep foo`)",
+    ),
+    (
+        re.compile(rf"{_ENV}{_PATH}(?<!-)rg{_EXE}\b"),
+        "rg (use the built-in Grep tool, or pipe another command's output"
+        " through rg — `cmd | rg foo`)",
+    ),
+]
 
-def split_command_chain(command: str) -> list[str]:
+
+def split_command_chain(command: str) -> list[tuple[str, bool]]:
     """Split on &&, ||, ;, | respecting quoted strings.
 
     Character-by-character parser tracking single/double quote state.
-    Returns stripped non-empty segments.
+    Returns stripped non-empty segments paired with an ``is_pipe_filter``
+    flag — True when the segment was produced by a ``|`` split (i.e. it
+    consumes another command's stdout).  Segments produced by ``&&``,
+    ``||``, ``;`` or as the first segment have the flag set to False.
     """
-    segments: list[str] = []
+    segments: list[tuple[str, bool]] = []
     current: list[str] = []
     in_single = False
     in_double = False
+    # Whether the segment currently being accumulated was preceded by `|`.
+    # The first segment has no preceding operator, so it is not a filter.
+    pending_is_filter = False
     i = 0
     length = len(command)
 
@@ -723,16 +746,18 @@ def split_command_chain(command: str) -> list[str]:
             if i + 1 < length and command[i : i + 2] in ("&&", "||"):
                 segment = "".join(current).strip()
                 if segment:
-                    segments.append(segment)
+                    segments.append((segment, pending_is_filter))
                 current = []
+                pending_is_filter = False
                 i += 2
                 continue
             # Check for ; or |
             if ch in (";", "|"):
                 segment = "".join(current).strip()
                 if segment:
-                    segments.append(segment)
+                    segments.append((segment, pending_is_filter))
                 current = []
+                pending_is_filter = ch == "|"
                 i += 1
                 continue
 
@@ -742,7 +767,7 @@ def split_command_chain(command: str) -> list[str]:
     # Final segment
     segment = "".join(current).strip()
     if segment:
-        segments.append(segment)
+        segments.append((segment, pending_is_filter))
 
     return segments
 
@@ -757,8 +782,10 @@ def check_command(command: str) -> str | None:
       2. Strip heredoc body to avoid false positives from string literals
       3. Normalize backslashes to forward slashes for consistent path matching
       4. Check presplit patterns on full text (pipe-to-shell detection)
-      5. Split command chains respecting quoted strings
-      6. Check each segment against BLOCKED_PATTERNS
+      5. Split command chains respecting quoted strings (each segment
+         tagged with whether it followed a `|`)
+      6. Check each segment against BLOCKED_PATTERNS, plus
+         LEADING_ONLY_PATTERNS for non-filter (non-pipe-downstream) segments
     """
     # 1. Heredoc-to-runtime check on raw command (before heredoc stripping)
     raw_normalized = command.replace("\\", "/")
@@ -784,14 +811,18 @@ def check_command(command: str) -> str | None:
             return "gh api (mutation)"
         return None
 
-    # 5. Split into chain segments
+    # 5. Split into chain segments (each tagged with is_pipe_filter)
     segments = split_command_chain(check_text)
 
     # 6. Check each segment against blocked patterns
-    for segment in segments:
+    for segment, is_filter in segments:
         for pattern, name in BLOCKED_PATTERNS:
             if pattern.search(segment):
                 return name
+        if not is_filter:
+            for pattern, name in LEADING_ONLY_PATTERNS:
+                if pattern.search(segment):
+                    return name
     return None
 
 

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -900,21 +900,37 @@ class TestCheckCommand:
     def test_network_tool_flag_false_positives_allowed(self, command: str) -> None:
         assert block_commands.check_command(command) is None
 
-    # --- Dedicated tools: grep/rg blocked (use built-in Grep tool) ---
+    # --- Dedicated tools: grep/rg blocked when leading (use built-in Grep tool) ---
+
+    GREP_BLOCKED_MSG = (
+        "grep (use the built-in Grep tool, or pipe another command's output"
+        " through grep — `cmd | grep foo`)"
+    )
+    RG_BLOCKED_MSG = (
+        "rg (use the built-in Grep tool, or pipe another command's output"
+        " through rg — `cmd | rg foo`)"
+    )
 
     @pytest.mark.parametrize(
         "command,expected",
         [
-            ("grep foo bar.txt", "grep (use the built-in Grep tool)"),
-            ("grep -r pattern .", "grep (use the built-in Grep tool)"),
-            ("grep -rn 'some pattern' src/", "grep (use the built-in Grep tool)"),
-            ("/usr/bin/grep foo", "grep (use the built-in Grep tool)"),
-            ("grep.exe foo bar", "grep (use the built-in Grep tool)"),
-            ("env grep foo", "grep (use the built-in Grep tool)"),
-            ("rg pattern", "rg (use the built-in Grep tool)"),
-            ("rg -t py pattern src/", "rg (use the built-in Grep tool)"),
-            ("/usr/bin/rg foo", "rg (use the built-in Grep tool)"),
-            ("rg.exe foo", "rg (use the built-in Grep tool)"),
+            ("grep foo bar.txt", GREP_BLOCKED_MSG),
+            ("grep -r pattern .", GREP_BLOCKED_MSG),
+            ("grep -rn 'some pattern' src/", GREP_BLOCKED_MSG),
+            ("/usr/bin/grep foo", GREP_BLOCKED_MSG),
+            ("grep.exe foo bar", GREP_BLOCKED_MSG),
+            ("env grep foo", GREP_BLOCKED_MSG),
+            ("rg pattern", RG_BLOCKED_MSG),
+            ("rg -t py pattern src/", RG_BLOCKED_MSG),
+            ("/usr/bin/rg foo", RG_BLOCKED_MSG),
+            ("rg.exe foo", RG_BLOCKED_MSG),
+            # Still blocked when grep/rg lead a chain segment after &&/||/;
+            ("true && grep foo bar.txt", GREP_BLOCKED_MSG),
+            ("false || grep foo bar.txt", GREP_BLOCKED_MSG),
+            ("ls; grep foo bar.txt", GREP_BLOCKED_MSG),
+            ("true && rg foo", RG_BLOCKED_MSG),
+            # Allowed downstream of `|` but reset by `&&` further along
+            ("ls | wc -l && grep foo bar.txt", GREP_BLOCKED_MSG),
         ],
     )
     def test_grep_rg_blocked(self, command: str, expected: str) -> None:
@@ -936,6 +952,13 @@ class TestCheckCommand:
             "cat target/output.txt",
             "ls merge-results/",
             "wc -l large_file.txt",
+            # Allowed as a downstream pipe filter
+            "semgrep --help 2>&1 | grep -A 3 -i test",
+            "ls -lh | grep foo",
+            "git log --oneline | grep fix",
+            "make help | rg test",
+            "echo hello | grep h | wc -l",
+            "cat file.txt | grep foo | rg bar",
         ],
     )
     def test_grep_rg_false_positives_allowed(self, command: str) -> None:
@@ -1445,35 +1468,76 @@ class TestSplitCommandChain:
     """Unit tests for the split_command_chain function."""
 
     def test_simple_and(self) -> None:
-        assert block_commands.split_command_chain("ls && pwd") == ["ls", "pwd"]
+        assert block_commands.split_command_chain("ls && pwd") == [
+            ("ls", False),
+            ("pwd", False),
+        ]
 
     def test_simple_or(self) -> None:
-        assert block_commands.split_command_chain("a || b") == ["a", "b"]
+        assert block_commands.split_command_chain("a || b") == [
+            ("a", False),
+            ("b", False),
+        ]
 
     def test_semicolon(self) -> None:
-        assert block_commands.split_command_chain("a; b") == ["a", "b"]
+        assert block_commands.split_command_chain("a; b") == [
+            ("a", False),
+            ("b", False),
+        ]
 
     def test_pipe(self) -> None:
-        assert block_commands.split_command_chain("a | b") == ["a", "b"]
+        assert block_commands.split_command_chain("a | b") == [
+            ("a", False),
+            ("b", True),
+        ]
+
+    def test_pipe_chain(self) -> None:
+        # Each segment after a `|` is flagged as a filter.
+        assert block_commands.split_command_chain("a | b | c") == [
+            ("a", False),
+            ("b", True),
+            ("c", True),
+        ]
+
+    def test_pipe_filter_resets_after_logical_operator(self) -> None:
+        # After && / || / ;, the next segment is no longer a pipe filter.
+        assert block_commands.split_command_chain("a | b && c") == [
+            ("a", False),
+            ("b", True),
+            ("c", False),
+        ]
+        assert block_commands.split_command_chain("a | b ; c") == [
+            ("a", False),
+            ("b", True),
+            ("c", False),
+        ]
 
     def test_mixed(self) -> None:
         result = block_commands.split_command_chain("a && b; c | d || e")
-        assert result == ["a", "b", "c", "d", "e"]
+        assert result == [
+            ("a", False),
+            ("b", False),
+            ("c", False),
+            ("d", True),
+            ("e", False),
+        ]
 
     def test_quoted_double(self) -> None:
         result = block_commands.split_command_chain('echo "a && b" && c')
-        assert result == ['echo "a && b"', "c"]
+        assert result == [('echo "a && b"', False), ("c", False)]
 
     def test_quoted_single(self) -> None:
         result = block_commands.split_command_chain("echo 'a | b'; c")
-        assert result == ["echo 'a | b'", "c"]
+        assert result == [("echo 'a | b'", False), ("c", False)]
 
     def test_empty_segments_stripped(self) -> None:
         result = block_commands.split_command_chain("a &&  && b")
-        assert result == ["a", "b"]
+        assert result == [("a", False), ("b", False)]
 
     def test_single_command(self) -> None:
-        assert block_commands.split_command_chain("git status") == ["git status"]
+        assert block_commands.split_command_chain("git status") == [
+            ("git status", False)
+        ]
 
 
 class TestPresplitPatterns:


### PR DESCRIPTION
The built-in Grep tool only searches files, so commands like
`semgrep --help | grep foo` had no allowlisted alternative.

- Move grep/rg from BLOCKED_PATTERNS into a new LEADING_ONLY_PATTERNS
  list, applied only to non-filter chain segments
- split_command_chain now returns (segment, is_pipe_filter) tuples,
  flagging segments produced by `|` so the leading-only patterns can
  be skipped on downstream filters while still blocking grep/rg at
  the start of a chain or after &&/||/;
- find stays fully blocked (no equivalent pipe-filter use case)

Assisted-by: Claude Code (Claude Opus 4.7)
