### PR TITLE
feat(block-commands): block file:// URI scheme in Bash commands

### DIFF
--- a/claude/settings.json.d/gate-assessment.json
+++ b/claude/settings.json.d/gate-assessment.json
@@ -11,17 +11,17 @@
       "Bash(python3 ~/.claude/skills/gate-assessment/scripts/generate_report.py *)",
       "Bash(python3 ~/.claude/skills/gate-assessment/scripts/write_feature.py *)",
       "Bash(python3 ~/.claude/skills/gate-assessment/scripts/write_measure.py *)",
-      "Glob(~/.claude/skills/gate-assessment/references/**)",
+      "Glob(*/.claude/skills/gate-assessment/references/**)",
       "Glob(~\\.claude\\skills\\gate-assessment\\references\\**)",
-      "Grep(~/.claude/skills/gate-assessment/references/**)",
+      "Grep(*/.claude/skills/gate-assessment/references/**)",
       "Grep(~\\.claude\\skills\\gate-assessment\\references\\**)",
-      "Read(~/.claude/skills/gate-assessment/references/**)",
+      "Read(*/.claude/skills/gate-assessment/references/**)",
       "Read(~\\.claude\\skills\\gate-assessment\\references\\**)"
     ],
     "deny": [
-      "Glob(~/.config/claude-skill-gate-assessment/.env)",
-      "Grep(~/.config/claude-skill-gate-assessment/.env)",
-      "Read(~/.config/claude-skill-gate-assessment/.env)"
+      "Glob(*/.config/claude-skill-gate-assessment/.env)",
+      "Grep(*/.config/claude-skill-gate-assessment/.env)",
+      "Read(*/.config/claude-skill-gate-assessment/.env)"
     ]
   }
 }

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -299,6 +299,8 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # PowerShell process/service cmdlets
     (re.compile(r"\bStop-Service\b", re.IGNORECASE), "Stop-Service"),
     (re.compile(r"\bStop-Process\b", re.IGNORECASE), "Stop-Process"),
+    # file:// URI scheme — agents should use the Read tool for local files
+    (re.compile(r"\bfile://"), "file:// URI (use the built-in Read tool)"),
     # Dedicated tools: block Bash find — use built-in Glob tool.
     # grep/rg are in LEADING_ONLY_PATTERNS because they are still useful as
     # downstream filters on another command's stdout (the built-in Grep tool

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -1177,6 +1177,35 @@ class TestCheckCommand:
         assert block_commands.check_command(cmd) == "git push"
 
 
+class TestFileUriBlocked:
+    """Block file:// URI scheme — agents should use Read tool."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl file:///etc/passwd",
+            "cat file:///tmp/secret.txt",
+            "xdg-open file:///home/user/doc.pdf",
+            "python3 -c 'open(\"file:///etc/hosts\")'",
+        ],
+    )
+    def test_file_uri_blocked(self, command: str) -> None:
+        assert (
+            block_commands.check_command(command)
+            == "file:// URI (use the built-in Read tool)"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl https://example.com/file",
+            "ls files/",
+        ],
+    )
+    def test_non_file_uri_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
 class TestInlineExecutionBlocks:
     """Block inline code execution for language runtimes."""
 


### PR DESCRIPTION
Agents should use the built-in Read tool for local file access, not
file:// URIs passed to shell commands.

Also updates gate-assessment settings paths to absolute form.

Assisted-by: Claude Code (Claude Opus 4.6)
