### PR TITLE
feat(block-commands): block cd && git pattern in favor of git -C

### DIFF
--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -38,7 +38,8 @@ Blocked categories:
   Publishing: npm publish, twine upload, gem push, cargo publish,
               dotnet nuget push
   Network: nc/netcat/ncat, scp, rsync, ftp/sftp, telnet, ssh, socat
-  Workflow: cd to cwd — cd <path> && <cmd> where path == cwd (context-aware)
+  Workflow: cd to cwd — cd <path> && <cmd> where path == cwd (context-aware),
+            cd && git — use git -C instead of cd <dir> && git <subcmd>
   Cross-platform: curl/wget piped to shell/interpreter (presplit)
               sh, bash, dash, ksh, csh, tcsh, zsh, fish,
               python, python3, pythonw, perl, ruby, node
@@ -119,6 +120,11 @@ PRESPLIT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(rf"\|\s*{_PATH}(?:{_PIPE_SHELLS}){_EXE}\b"),
         "pipe to runtime (inline execution — file a missing test instead)",
+    ),
+    # cd <dir> && git <subcmd>: use git -C <dir> <subcmd> instead
+    (
+        re.compile(r"\bcd\s+\S+\s*&&\s*" rf"{_ENV}{_PATH}git{_EXE}\b"),
+        "cd && git (use git -C <dir> instead)",
     ),
 ]
 

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -1641,6 +1641,40 @@ class TestPresplitPatterns:
         assert block_commands.check_command(command) is None
 
 
+class TestCdAndGitBlocked:
+    """Block cd <dir> && git — use git -C <dir> instead."""
+
+    _MSG = "cd && git (use git -C <dir> instead)"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cd /other/repo && git log",
+            "cd ../sibling && git status",
+            "cd ~/source/project && git diff --staged",
+            "cd subdir && git branch -a",
+            "cd /tmp/repo && git rev-parse HEAD",
+        ],
+    )
+    def test_cd_and_git_blocked(self, command: str) -> None:
+        assert block_commands.check_command(command) == self._MSG
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # cd && non-git — not blocked by this rule
+            "cd /tmp && ls",
+            # git -C is the correct pattern
+            "git -C /other/repo log",
+            # No cd at all
+            "git diff --staged",
+        ],
+    )
+    def test_cd_without_git_allowed(self, command: str) -> None:
+        result = block_commands.check_command(command)
+        assert result != self._MSG
+
+
 class TestCdToCwd:
     """Block cd <path> && <cmd> only when path resolves to cwd."""
 


### PR DESCRIPTION
Agents frequently use cd <dir> && git <subcmd> instead of the
equivalent git -C <dir> <subcmd>. The -C form is already allowlisted
for read-only subcommands and avoids unnecessary cd chaining.

Assisted-by: Claude Code (Claude Opus 4.6)
