### PR TITLE
feat(reconcile): deploy config/ subdirs to ~/.config/ and clean output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: install install-dev install-no-deps uninstall clean format test-format test-lint test-typecheck test-unit test-verbose test-coverage check help migrate reconcile
 
+MAKEFLAGS += --no-print-directory
 .DEFAULT_GOAL := check
 
 VENV_DIR ?= .venv

--- a/config/ai-guardian/ai-guardian.json
+++ b/config/ai-guardian/ai-guardian.json
@@ -1,0 +1,11 @@
+{
+    "permissions": [
+        {
+            "matcher": "Skill",
+            "mode": "allow",
+            "patterns": [
+                "*"
+            ]
+        }
+    ]
+}

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -194,6 +194,49 @@ def reconcile_settings(
     return True
 
 
+def reconcile_config_dir(
+    src_dir: Path,
+    dest_dir: Path,
+    *,
+    dryrun: bool = False,
+    quiet: bool = False,
+) -> bool:
+    """Copy all files from src_dir to dest_dir (non-recursive).
+
+    Skips files that are already identical. Creates dest_dir if needed.
+    Returns True if any file changed.
+    """
+    if not src_dir.is_dir():
+        return False
+
+    changed = False
+    for src_file in sorted(src_dir.iterdir()):
+        if not src_file.is_file():
+            continue
+        dest_file = dest_dir / src_file.name
+        try:
+            if dest_file.exists() and src_file.read_text(
+                encoding="utf-8"
+            ) == dest_file.read_text(encoding="utf-8"):
+                continue
+        except OSError:
+            pass
+
+        changed = True
+        if dryrun:
+            print(f"Would copy: {src_file} -> {dest_file}")
+        else:
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_file, dest_file)
+            if not quiet:
+                print(f"Copied: {src_file} -> {dest_file}")
+
+    if not changed:
+        logger.info("%s already in sync", src_dir.name)
+
+    return changed
+
+
 def reconcile_scripts(
     repo_dir: Path,
     dest_dir: Path,
@@ -275,6 +318,16 @@ def main(argv=None):
         changed |= reconcile_scripts(
             args.src.parent, args.dest, dryrun=args.dryrun, quiet=args.quiet
         )
+        config_dir = args.src.parent / "config"
+        if config_dir.is_dir():
+            for subdir in sorted(config_dir.iterdir()):
+                if subdir.is_dir():
+                    changed |= reconcile_config_dir(
+                        subdir,
+                        Path.home() / ".config" / subdir.name,
+                        dryrun=args.dryrun,
+                        quiet=args.quiet,
+                    )
     except (json.JSONDecodeError, OSError) as exc:
         logger.error(f"reconcile failed: {exc}")
         return EXIT_ERROR

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -16,6 +16,7 @@ from scripts.reconcile import (
     main,
     merge_settings,
     reconcile_claude_md,
+    reconcile_config_dir,
     reconcile_scripts,
     reconcile_settings,
 )
@@ -419,6 +420,73 @@ class TestReconcileScripts:
         dest_scripts = dest_dir / "my-claude-stuff" / "scripts"
         assert (dest_scripts / "good.py").exists()
         assert not (dest_scripts / "notes.txt").exists()
+
+
+class TestReconcileConfigDir:
+    def test_copies_files(self, tmp_path):
+        src_dir = tmp_path / "src"
+        dest_dir = tmp_path / "dest"
+        src_dir.mkdir()
+        (src_dir / "config.json").write_text('{"key": "value"}')
+
+        changed = reconcile_config_dir(src_dir, dest_dir)
+
+        assert changed is True
+        assert (dest_dir / "config.json").read_text() == '{"key": "value"}'
+
+    def test_skips_identical(self, tmp_path):
+        src_dir = tmp_path / "src"
+        dest_dir = tmp_path / "dest"
+        src_dir.mkdir()
+        dest_dir.mkdir()
+        (src_dir / "config.json").write_text("same")
+        (dest_dir / "config.json").write_text("same")
+
+        changed = reconcile_config_dir(src_dir, dest_dir)
+
+        assert changed is False
+
+    def test_overwrites_changed(self, tmp_path):
+        src_dir = tmp_path / "src"
+        dest_dir = tmp_path / "dest"
+        src_dir.mkdir()
+        dest_dir.mkdir()
+        (src_dir / "config.json").write_text("new")
+        (dest_dir / "config.json").write_text("old")
+
+        changed = reconcile_config_dir(src_dir, dest_dir)
+
+        assert changed is True
+        assert (dest_dir / "config.json").read_text() == "new"
+
+    def test_missing_src_dir(self, tmp_path):
+        changed = reconcile_config_dir(tmp_path / "nonexistent", tmp_path / "dest")
+
+        assert changed is False
+
+    def test_dryrun_does_not_write(self, tmp_path):
+        src_dir = tmp_path / "src"
+        dest_dir = tmp_path / "dest"
+        src_dir.mkdir()
+        (src_dir / "config.json").write_text("content")
+
+        changed = reconcile_config_dir(src_dir, dest_dir, dryrun=True)
+
+        assert changed is True
+        assert not (dest_dir / "config.json").exists()
+
+    def test_skips_subdirectories(self, tmp_path):
+        src_dir = tmp_path / "src"
+        dest_dir = tmp_path / "dest"
+        src_dir.mkdir()
+        (src_dir / "config.json").write_text("ok")
+        (src_dir / "subdir").mkdir()
+        (src_dir / "subdir" / "nested.json").write_text("skip")
+
+        reconcile_config_dir(src_dir, dest_dir)
+
+        assert (dest_dir / "config.json").exists()
+        assert not (dest_dir / "subdir").exists()
 
 
 class TestMain:


### PR DESCRIPTION
- Add reconcile_config_dir() for flat file copy with sync detection
- Auto-discover config/<name>/ and deploy to ~/.config/<name>/
- Add ai-guardian config as first config/ consumer
- Suppress make Entering/Leaving directory noise

Assisted-by: Claude Code (Claude Opus 4.6)
