### PR TITLE
feat(ai-guardian): allow mcp__allowlist__get_allowed_permissions

### DIFF
--- a/config/ai-guardian/ai-guardian.json
+++ b/config/ai-guardian/ai-guardian.json
@@ -1,6 +1,13 @@
 {
     "permissions": [
         {
+            "matcher": "mcp__*",
+            "mode": "allow",
+            "patterns": [
+                "mcp__allowlist__get_allowed_permissions"
+            ]
+        },
+        {
             "matcher": "Skill",
             "mode": "allow",
             "patterns": [


### PR DESCRIPTION
Add mcp__* matcher block permitting the allowlist permission-query tool
so it can be called without prompting.

Assisted-by: Claude Code (Claude Opus 4.7)
