### PR TITLE
feat(ai-guardian): disable credit_card PII detector

### DIFF
--- a/config/ai-guardian/ai-guardian.json
+++ b/config/ai-guardian/ai-guardian.json
@@ -14,5 +14,19 @@
                 "*"
             ]
         }
-    ]
+    ],
+    "scan_pii": {
+        "enabled": true,
+        "pii_types": [
+            "ssn",
+            "phone",
+            "us_passport",
+            "iban",
+            "intl_phone"
+        ],
+        "action": "block",
+        "ignore_files": [],
+        "ignore_tools": [],
+        "allowlist_patterns": []
+    }
 }


### PR DESCRIPTION
Persistent false positives blocked file reads in many locations. Override
default scan_pii.pii_types to omit credit_card; SSN, phone, passport,
IBAN, and intl_phone detection remain on.

Full scan_pii block required because _load_config_section replaces
defaults entirely on user override (no deep merge).

Assisted-by: Claude Code (Claude Opus 4.7)
