### PR TITLE
feat(sed): block mutating sed, allow read-only line-range print

### DIFF
--- a/claude/settings.json.d/sed-readonly.json
+++ b/claude/settings.json.d/sed-readonly.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(sed -n *)"
+    ]
+  }
+}

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -54,6 +54,8 @@ Blocked categories:
        process substitution (``<runtime> <(...)``),
        shell -c wrapping a runtime (``bash -c "python ..."``),
        arbitrary ``python <path>.py`` outside ``scripts/`` directories
+  Sed: all sed invocations except read-only line-range print
+       (sed -n '<range>p' — use Read tool with offset/limit instead)
   Package install: pip install, npm install, cargo install, go install
   Semgrep: --autofix/-a/--replacement (mutation), login/logout/publish/
            install-semgrep-pro (state or network egress)
@@ -394,6 +396,15 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         ),
         "running arbitrary .py file (use Read/Glob/Grep; "
         "file a missing test if runtime verification is required)",
+    ),
+    # sed: block all except read-only line-range print (sed -n '<range>p')
+    (
+        re.compile(
+            rf"{_ENV}{_PATH}sed{_EXE}\b"
+            r"(?!\s+-n\s+['\"]?\d+(?:,\d+)?p['\"]?(?:\s|\Z))"
+        ),
+        "sed (use the built-in Read tool with offset/limit, "
+        "or sed -n '<range>p' for line extraction)",
     ),
     # Package installation against the user's environment
     (

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -1407,6 +1407,57 @@ class TestInlineExecutionBlocks:
         assert block_commands.check_command(command) is None
 
 
+class TestSedBlocked:
+    """sed must be blocked except for read-only line-range print."""
+
+    _MSG = (
+        "sed (use the built-in Read tool with offset/limit, "
+        "or sed -n '<range>p' for line extraction)"
+    )
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("sed 's/foo/bar/' file.txt", _MSG),
+            ("sed -i 's/foo/bar/' file.txt", _MSG),
+            ("sed -e 's/foo/bar/' file.txt", _MSG),
+            ("sed -n 's/foo/bar/p' file.txt", _MSG),
+            ("sed -n '/pattern/p' file.txt", _MSG),
+            ("sed -n '1,6d' file.txt", _MSG),
+            ("sed -n '1,6w output.txt' file.txt", _MSG),
+            ("sed '1,6p' file.txt", _MSG),
+            ("/usr/bin/sed 's/foo/bar/' file.txt", _MSG),
+            ("sed.exe -i 's/a/b/' file.txt", _MSG),
+            ("env sed 's/x/y/' file.txt", _MSG),
+        ],
+    )
+    def test_blocked(self, command: str, expected: str) -> None:
+        assert block_commands.check_command(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sed -n '1,6p' file.txt",
+            "sed -n '89,90p' file.txt",
+            "sed -n '5p' file.txt",
+            "sed -n 1,6p file.txt",
+            "sed -n '100,200p' /path/to/file.md",
+        ],
+    )
+    def test_line_range_print_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat file.txt | sed -n '1,6p'",
+            "cat /path/to/file.md | sed -n '89,90p'",
+        ],
+    )
+    def test_piped_line_range_print_allowed(self, command: str) -> None:
+        assert block_commands.check_command(command) is None
+
+
 class TestPackageInstallBlocks:
     """Block package installation against the user's environment."""
 


### PR DESCRIPTION
Hook in block_commands.py blocks all sed except `sed -n '<range>p'`.
Permission glob `Bash(sed -n *)` auto-allows without approval prompts,
with hook as defense-in-depth against non-print sed -n invocations.

Assisted-by: Claude Code (Claude Opus 4.6)
