### PR TITLE
fix(ai-guardian): allow localhost and update permissions schema

### DIFF
--- a/config/ai-guardian/ai-guardian.json
+++ b/config/ai-guardian/ai-guardian.json
@@ -1,20 +1,23 @@
 {
-    "permissions": [
-        {
-            "matcher": "mcp__*",
-            "mode": "allow",
-            "patterns": [
-                "mcp__allowlist__get_allowed_permissions"
-            ]
-        },
-        {
-            "matcher": "Skill",
-            "mode": "allow",
-            "patterns": [
-                "*"
-            ]
-        }
-    ],
+    "permissions": {
+        "enabled": true,
+        "rules": [
+            {
+                "matcher": "mcp__*",
+                "mode": "allow",
+                "patterns": [
+                    "mcp__allowlist__get_allowed_permissions"
+                ]
+            },
+            {
+                "matcher": "Skill",
+                "mode": "allow",
+                "patterns": [
+                    "*"
+                ]
+            }
+        ]
+    },
     "scan_pii": {
         "enabled": true,
         "pii_types": [
@@ -26,5 +29,8 @@
         "ignore_files": [],
         "ignore_tools": [],
         "allowlist_patterns": []
+    },
+    "ssrf_protection": {
+        "allow_localhost": true
     }
 }


### PR DESCRIPTION
- Add ssrf_protection.allow_localhost to unblock local Loki queries
- Restructure permissions from array to object with enabled + rules

Assisted-by: Claude Code (Claude Opus 4.6)
