### PR TITLE
feat(block-commands): block git --git-dir, redirect to git -C

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,9 @@ Claude Code configuration management repo. The `claude/` directory is the source
 ## Restricted Operations
 
 - **`make reconcile` is USER ONLY** — never run it. It deploys scripts and config to `~/.claude/` which affects the live Claude Code environment. Only the user decides when to deploy.
+
+## ai-guardian Config
+
+- Edit ai-guardian config at `config/ai-guardian/ai-guardian.json` (deploys to `~/.config/ai-guardian/ai-guardian.json` via `make reconcile`).
+- Config sections (`scan_pii`, `secret_scanning`, `prompt_injection`, `config_file_scanning`, etc.) **replace defaults wholesale** — ai-guardian's `_load_config_section` in [config_loaders.py](https://github.com/jewzaam/my-claude-stuff) returns `config.get(key, defaults)` with no deep merge.
+- To override one field in a section, reproduce the **entire section** (all sibling fields: `enabled`, `action`, `ignore_files`, `ignore_tools`, `allowlist_patterns`, etc.) from defaults. Omitting siblings silently drops them.

--- a/scripts/block_commands.py
+++ b/scripts/block_commands.py
@@ -20,6 +20,7 @@ Blocked categories:
   Git: -C flag (blocked for absolute/parent/home paths;
        exceptions: relative subdirectory paths, git-worktrees/ paths,
        read-only subcommands: status/log/diff),
+       --git-dir / --git-dir= (use -C instead),
        add, push, reset, clean (except -n),
        branch (destructive flags only),
        stash (except list/show), commit --amend/-a, checkout -- (discard),
@@ -152,6 +153,13 @@ BLOCKED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         ),
         "git -C (blocked for absolute/parent/home paths"
         " — subdirectory and worktree paths are allowed)",
+    ),
+    # git --git-dir / --git-dir=: redirect users to git -C, which honors
+    # the worktree/read-only/subdirectory rules above. --git-dir bypasses
+    # those rules and is harder to reason about.
+    (
+        re.compile(rf"{_ENV}{_PATH}git{_EXE}\s+--git-dir(?:=|\s)"),
+        "git --git-dir (use git -C <dir> instead)",
     ),
     (re.compile(rf"{_ENV}{_PATH}git{_EXE}{_FLAGS}\s+add\b"), "git add"),
     (re.compile(rf"{_ENV}{_PATH}git{_EXE}{_FLAGS}\s+push\b"), "git push"),

--- a/tests/test_block_commands.py
+++ b/tests/test_block_commands.py
@@ -159,6 +159,22 @@ class TestCheckCommand:
     def test_git_dash_c_readonly_allowed(self, command: str) -> None:
         assert block_commands.check_command(command) is None
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git --git-dir=/some/path/.git status",
+            "git --git-dir /some/path/.git status",
+            "git --git-dir=../parent/.git log",
+            "git --git-dir ~/repo/.git fetch",
+            "/usr/bin/git --git-dir=/repo/.git branch",
+            "env git --git-dir=/repo/.git push",
+        ],
+    )
+    def test_git_dir_blocked(self, command: str) -> None:
+        result = block_commands.check_command(command)
+        assert result is not None
+        assert "--git-dir" in result
+
     def test_su_standalone(self) -> None:
         assert block_commands.check_command("su") == "su"
         assert block_commands.check_command("su -") == "su"
@@ -225,7 +241,6 @@ class TestCheckCommand:
     @pytest.mark.parametrize(
         "command,expected",
         [
-            ("git --git-dir=/tmp/.git add .", "git add"),
             ("git -c user.name=test push", "git push"),
         ],
     )


### PR DESCRIPTION
The --git-dir / --git-dir= flags bypass the existing git -C
worktree/read-only/subdirectory rules and are harder to reason about.
Block both forms with a message pointing users to git -C, which honors
the cwd-relative path policy.

Also document the ai-guardian config override semantic in project
CLAUDE.md: scan_pii (and other sections loaded via
_load_config_section) replace defaults wholesale on user override, so
single-field tweaks require reproducing the whole section.

Assisted-by: Claude Code (Claude Opus 4.7)
