### PR TITLE
fix(ai-guardian): add Skill permissions and explicit action blocks

### DIFF
--- a/config/ai-guardian/ai-guardian.json
+++ b/config/ai-guardian/ai-guardian.json
@@ -7,6 +7,13 @@
                 "patterns": [
                     "*"
                 ]
+      },
+      {
+        "matcher": "Skill",
+        "mode": "allow",
+        "patterns": [
+          "*"
+        ]
             }
         ]
     },
@@ -17,10 +24,12 @@
             "iban",
             "intl_phone",
             "address"
-        ]
+    ],
+    "action": "block"
     },
     "ssrf_protection": {
-        "allow_localhost": true
+    "allow_localhost": true,
+    "action": "block"
     },
     "daemon": {
         "mode": "local",
@@ -30,5 +39,27 @@
     },
     "security_instructions": {
         "inject_on_prompt": false
+  },
+  "mcp_server": {
+    "proactive_level": "low"
+  },
+  "secret_scanning": {
+    "execution_strategy": "first-match"
+  },
+  "directory_rules": {
+    "action": "block"
+  },
+  "console": {
+    "editor_theme": "monokai"
+  },
+  "on_scan_error": "allow",
+  "secret_redaction": {
+    "action": "warn"
+  },
+  "prompt_injection": {
+    "action": "block"
+  },
+  "config_file_scanning": {
+    "action": "block"
     }
 }


### PR DESCRIPTION
- Allow all Skill tool patterns in permissions rules
- Add explicit block actions for scan_pii, ssrf_protection,
  prompt_injection, config_file_scanning, and directory_rules
- Add secret_redaction with warn action
- Set secret_scanning to first-match execution strategy
- Configure mcp_server proactive_level to low
- Set on_scan_error to allow

Assisted-by: Claude Code (Claude Opus 4.6)
