### PR TITLE
fix(ai-guardian): require dual-engine consensus for secret scanning

### DIFF
--- a/config/ai-guardian/ai-guardian.json
+++ b/config/ai-guardian/ai-guardian.json
@@ -50,7 +50,12 @@
     "allowlist_patterns": [
       "docs\\.google\\.com/(document|spreadsheets|presentation|forms)/d/[a-zA-Z0-9_-]+",
       "drive\\.google\\.com/(file|drive)/(d|folders)/[a-zA-Z0-9_-]+"
-    ]
+    ],
+    "engines": [
+      "betterleaks",
+      "gitleaks"
+    ],
+    "consensus_threshold": 2
   },
   "directory_rules": {
     "action": "block"


### PR DESCRIPTION
- Add betterleaks and gitleaks as secret scanning engines
- Set consensus_threshold to 2 to reduce false positives

Assisted-by: Claude Code (Claude Opus 4.6)
