### PR TITLE
feat: add openshell permissions and soften prompt injection action

### DIFF
--- a/claude/settings.json.d/openshell.json
+++ b/claude/settings.json.d/openshell.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(openshell * --help)",
+      "Bash(openshell gateway list)",
+      "Bash(openshell sandbox list)"
+    ]
+  }
+}

--- a/config/ai-guardian/ai-guardian.json
+++ b/config/ai-guardian/ai-guardian.json
@@ -69,7 +69,7 @@
     "enabled": true
   },
   "prompt_injection": {
-    "action": "block",
+    "action": "warn",
     "enabled": true,
     "unicode_detection": {
       "enabled": true,


### PR DESCRIPTION
- Add openshell settings fragment with help, gateway list, sandbox list
- Change prompt_injection action from block to warn

Assisted-by: Claude Code (Claude Opus 4.6)
