### PR TITLE
feat(hooks): add noop hooks for full OTEL event coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Claude Code configuration and statusline scripts with cross-platform support (Li
 
 - `claude/` — Claude Code config files (`CLAUDE.md`, `settings.json.d/`)
 - `scripts/` — Python scripts for statusline, session tracking, and command blocking
-- Third-party hooks: [ai-guardian](https://github.com/itdove/ai-guardian), [claude-dashboard](https://github.com/syther-labs/claude-dashboard)
+- Hook fragments: [ai-guardian](https://github.com/itdove/ai-guardian) (security scanning), noop (OTEL event coverage)
 - `docs/` — Design docs and reference material
 - `Makefile` — Standard targets (format, lint, typecheck, test, coverage)
 

--- a/claude/settings.json.d/hooks-noop.json
+++ b/claude/settings.json.d/hooks-noop.json
@@ -1,0 +1,194 @@
+{
+  "hooks": {
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "Setup": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "command": "python3 -c \"\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-This repo uses Claude Code hooks to block destructive commands and log prompts/responses/questions. Custom hooks are in `claude/settings.json.d/hooks-my-claude-stuff.json`. Third-party hooks are in separate fragments: `hooks-ai-guardian.json`, `hooks-claude-dashboard.json`. All deployed via `make reconcile`.
+This repo uses Claude Code hooks to block destructive commands and log prompts/responses/questions. Custom hooks are in `claude/settings.json.d/hooks-my-claude-stuff.json`. Additional fragments: `hooks-ai-guardian.json` (security scanning), `hooks-noop.json` (OTEL event coverage). All deployed via `make reconcile`.
 
 ## What Are Hooks
 
@@ -38,11 +38,11 @@ Configuration lives in `claude/settings.json.d/hooks-my-claude-stuff.json`.
 | `Notification` | `*` | Scan tool output for injection/leakage |
 | `UserPromptSubmit` | `*` | Scan user prompts |
 
-#### claude-dashboard (`hooks-claude-dashboard.json`)
+#### hooks-noop (`hooks-noop.json`)
 
-[claude-dashboard](https://github.com/syther-labs/claude-dashboard) relays all lifecycle events to a local dashboard for real-time session monitoring.
-
-Hooks on all events: `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PostToolUseFailure`, `Stop`, `StopFailure`, `SessionEnd`, `Notification`, `SubagentStart`, `SubagentStop`.
+No-op hooks covering every event type. Required so Claude Code emits OTEL data for all events —
+presence of a hook gates OTEL emission. See [`docs/noop-hooks.md`](noop-hooks.md) for full
+explanation.
 
 ## Prompt Log Hook (`scripts/prompt_log.py`)
 

--- a/docs/noop-hooks.md
+++ b/docs/noop-hooks.md
@@ -1,0 +1,53 @@
+# No-op Hooks: Why They Exist
+
+## Root Cause
+
+Claude Code does **not** emit an OTEL event for a hook type unless at least one hook of that type is
+configured in `settings.json`. The event is simply never written to the telemetry pipeline.
+
+Confirmed for `PermissionRequest`: when no `PermissionRequest` hook exists, the session goes
+completely silent at the permission dialog. `tool_decision` only fires *after* the user responds.
+Zero telemetry while waiting — and zero telemetry if no hook is defined at all.
+
+This is a Claude Code internal behavior: hook presence gates OTEL event emission. It is not
+documented as such; it was discovered by observing that `hook_event="PermissionRequest"` never
+appeared in Loki despite the `claude_session_permission` recording rule being logically correct.
+
+## Fix
+
+`claude/settings.json.d/hooks-noop.json` registers a no-op command (`python3 -c ""`) for every
+known hook event type:
+
+- `ConfigChange`
+- `Notification`
+- `PermissionRequest`
+- `PostToolUse`
+- `PostToolUseFailure`
+- `PreCompact`
+- `PreToolUse`
+- `SessionEnd`
+- `SessionStart`
+- `Setup`
+- `Stop`
+- `StopFailure`
+- `SubagentStart`
+- `SubagentStop`
+- `TaskCompleted`
+- `TeammateIdle`
+- `UserPromptSubmit`
+- `WorktreeCreate`
+- `WorktreeRemove`
+
+The command exits 0 immediately and produces no output. Its only purpose is to satisfy the
+presence check so all event types flow through the OTEL pipeline.
+
+## Consequence
+
+Any OTEL-based alerting or recording rule that depends on a hook event type **requires** a hook of
+that type to exist — even if the hook does nothing. If a new event type is added to Claude Code and
+you want to observe it, add it here.
+
+## Cross-Platform Note
+
+`python3 -c ""` is used rather than `true` because Claude Code on Windows may invoke hooks via a
+shell where `true` is not available. Python is a project dependency, guaranteed present.


### PR DESCRIPTION
Claude Code only emits OTEL for event types that have at least one hook
configured. Without a hook, the event never enters the telemetry pipeline.
Confirmed on PermissionRequest: silent at permission dialog with no hook
defined.

- Add hooks-noop.json with python3 -c "" for all 19 known event types
- Add docs/noop-hooks.md explaining root cause, fix, and consequence
- Update docs/hooks.md: replace claude-dashboard section with noop entry
- Update README to reflect current hook fragments

Assisted-by: Claude Code (Claude Sonnet 4.6)
