### PR TITLE
feat(settings): raise AFK timeouts to work around AskUserQuestion bug

### DIFF
--- a/claude/settings.json.d/bug-AskUserQuestion-timeout.json
+++ b/claude/settings.json.d/bug-AskUserQuestion-timeout.json
@@ -1,0 +1,7 @@
+{
+  "_source": ["https://github.com/anthropics/claude-code/issues/73125", "https://github.com/anthropics/claude-code/issues/73408"],
+  "env": {
+    "CLAUDE_AFK_TIMEOUT_MS": "86400000",
+    "CLAUDE_AFK_COUNTDOWN_MS": "86400000"
+  }
+}


### PR DESCRIPTION
Set CLAUDE_AFK_TIMEOUT_MS and CLAUDE_AFK_COUNTDOWN_MS to 24h so
AskUserQuestion prompts do not time out prematurely.

Refs: anthropics/claude-code#73125, anthropics/claude-code#73408
Assisted-by: Claude Code (Claude Opus 4.8)
