### PR TITLE
chore(settings): prune official plugins, register marketplace plugins

### DIFF
--- a/claude/settings.json.d/plugins.json
+++ b/claude/settings.json.d/plugins.json
@@ -1,18 +1,22 @@
 {
   "autoUpdatesChannel": "latest",
   "enabledPlugins": {
-    "atlassian@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
-    "feature-dev@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true,
+    "atlassian@claude-plugins-official": false,
+    "claude-code-setup@claude-plugins-official": false,
+    "claude-md-management@claude-plugins-official": false,
+    "code-simplifier@claude-plugins-official": false,
+    "feature-dev@claude-plugins-official": false,
+    "security-guidance@claude-plugins-official": false,
     "skill-creator@claude-plugins-official": true,
     "superpowers@superpowers-dev": true,
-    "plugin-dev@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": false,
     "jewzaam-reviews@jewzaam-reviews-marketplace": true,
     "caveman@caveman": true,
-    "ponytail@ponytail": true
+    "ponytail@ponytail": true,
+    "docs-tools@ccs-ai-agentic-workflow": false,
+    "jtbd-tools@redhat-docs-agent-tools": false,
+    "nexus-dev-env@matburt-nexus-dev-env": false,
+    "uxd-workshop@uxd-ai-helpers": false
   },
   "extraKnownMarketplaces": {
     "superpowers-dev": {


### PR DESCRIPTION
Disable official plugins (atlassian, code-simplifier, feature-dev,
security-guidance, plugin-dev, claude-md-management, claude-code-setup).
Register four new marketplace plugins (docs-tools, jtbd-tools,
nexus-dev-env, uxd-workshop) as disabled. Retain skill-creator,
superpowers, jewzaam-reviews, caveman, ponytail.

Assisted-by: Claude Code (Claude Sonnet 4.5)
